### PR TITLE
Reject oversized bracket H-count and saturate valence math

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,1 @@
+https://files.docking.org/zinc20-ML/smiles/ZINC20_smiles_chunk_

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -57,6 +57,15 @@ pub enum SmilesError {
     /// Error indicating invalid Element name
     #[error("Invalid element name: {0}")]
     InvalidElementName(char),
+    /// A bracket atom's explicit hydrogen count exceeds the maximum supported
+    /// value (15).
+    ///
+    /// The cap mirrors the magnitude cap on bracket-atom charges and prevents
+    /// downstream `u8` valence math (`explicit_valence + hydrogen_count +
+    /// implicit_hydrogen_count`) from overflowing for adversarial inputs.
+    /// Real chemistry SMILES never need an explicit `H` count above this bound.
+    #[error("Hydrogen count overflow: {0}")]
+    HydrogenCountOverflow(u8),
     /// A hydrogen bracket atom has an unsupported explicit hydrogen count
     #[error("Hydrogen found as bracketed atom with an unsupported explicit hydrogen count")]
     InvalidHydrogenWithExplicitHydrogensFound,
@@ -300,6 +309,7 @@ mod tests {
                 SmilesError::IncompleteBond(BondDescriptor::aromatic(Bond::Single)),
                 "Bond: : missing atom index(es)".to_string(),
             ),
+            (SmilesError::HydrogenCountOverflow(16), "Hydrogen count overflow: 16".to_string()),
             (
                 SmilesError::InvalidAromaticElement(Element::Ac),
                 format!("Invalid aromatic element: {}", Element::Ac),

--- a/src/parser/token_iter.rs
+++ b/src/parser/token_iter.rs
@@ -451,14 +451,25 @@ where
     Some(B::try_from(amount).map_err(|_| SmilesError::IntegerOverflow))
 }
 
+/// Maximum bracket-atom explicit hydrogen count accepted by the parser.
+///
+/// Chosen to mirror the magnitude cap on bracket-atom charges. Real chemistry
+/// SMILES do not require explicit hydrogen counts above this bound, and
+/// bounding the value here keeps downstream `u8` valence math from overflowing.
+const MAX_HYDROGEN_COUNT: u8 = 15;
+
 #[inline]
 fn hydrogen_count(stream: &mut TokenIter<'_>) -> Result<u8, SmilesError> {
     if stream.peek_byte() == Some(b'H') {
         let _ = stream.next_byte();
-        match try_fold_number::<u8, 3>(stream) {
-            Some(h) => Ok(h?),
-            None => Ok(1),
+        let count = match try_fold_number::<u8, 3>(stream) {
+            Some(h) => h?,
+            None => 1,
+        };
+        if count > MAX_HYDROGEN_COUNT {
+            return Err(SmilesError::HydrogenCountOverflow(count));
         }
+        Ok(count)
     } else {
         Ok(0)
     }
@@ -882,6 +893,15 @@ mod tests {
 
         let mut stream = TokenIter::from("C");
         assert_eq!(hydrogen_count(&mut stream), Ok(0));
+
+        let mut stream = TokenIter::from("H15");
+        assert_eq!(hydrogen_count(&mut stream), Ok(15));
+
+        let mut stream = TokenIter::from("H16");
+        assert_eq!(hydrogen_count(&mut stream), Err(SmilesError::HydrogenCountOverflow(16)));
+
+        let mut stream = TokenIter::from("H254");
+        assert_eq!(hydrogen_count(&mut stream), Err(SmilesError::HydrogenCountOverflow(254)));
     }
 
     #[test]

--- a/src/smiles/implicit_hydrogens.rs
+++ b/src/smiles/implicit_hydrogens.rs
@@ -121,7 +121,7 @@ fn implicit_hydrogens_for_node<AtomPolicy: SmilesAtomPolicy>(
     node_id: usize,
     node: &Atom,
 ) -> u8 {
-    let explicit_valence = explicit_valence(smiles, node_id);
+    let explicit_valence = saturated_explicit_valence(smiles, node_id);
     match node.syntax() {
         AtomSyntax::Bracket => 0,
         AtomSyntax::OrganicSubset => {
@@ -145,7 +145,7 @@ pub(super) fn implicit_hydrogens_if_written_unbracketed(
     node_id: usize,
     node: &Atom,
 ) -> u8 {
-    let explicit_valence = explicit_valence(smiles, node_id);
+    let explicit_valence = saturated_explicit_valence(smiles, node_id);
     match node.symbol() {
         AtomSymbol::WildCard => 0,
         AtomSymbol::Element(element) => {
@@ -166,9 +166,30 @@ pub(super) fn implicit_hydrogens_if_written_unbracketed(
 ///
 /// This split also mirrors raw `RDKit`: bracket hydrogens stay explicit instead
 /// of being folded back into a later implicit-hydrogen completion step.
+///
+/// The return type is `u16` because adversarial SMILES inputs (very large
+/// degree, all quadruple bonds, ...) can drive the sum past 255. Real chemistry
+/// values are tiny, but the wider arithmetic keeps the parser from panicking on
+/// pathological inputs. Callers that need the value in `u8` should saturate.
 #[inline]
-pub(crate) fn explicit_valence(smiles: &Smiles<impl SmilesAtomPolicy>, node_id: usize) -> u8 {
-    smiles.bond_matrix().sparse_row_values_ref(node_id).map(|entry| bond_order(entry.bond())).sum()
+pub(crate) fn explicit_valence(smiles: &Smiles<impl SmilesAtomPolicy>, node_id: usize) -> u16 {
+    smiles
+        .bond_matrix()
+        .sparse_row_values_ref(node_id)
+        .map(|entry| u16::from(bond_order(entry.bond())))
+        .sum()
+}
+
+/// Returns [`explicit_valence`] saturated into `u8`.
+///
+/// The internal valence-completion helpers (`aliphatic_implicit_hydrogens` and
+/// friends) operate on `u8` because every element's chemistry-scale valence
+/// table fits in `u8`. Saturating here is safe: when the parsed graph already
+/// exceeds any element's maximum valence, no completion candidate exists and
+/// implicit-hydrogen counting returns zero either way.
+#[inline]
+fn saturated_explicit_valence(smiles: &Smiles<impl SmilesAtomPolicy>, node_id: usize) -> u8 {
+    u8::try_from(explicit_valence(smiles, node_id)).unwrap_or(u8::MAX)
 }
 
 /// Maps parsed bond syntax to the local bond-order contribution used for raw
@@ -303,6 +324,20 @@ mod tests {
         assert_eq!(explicit_valence(&smiles, 0), 4);
         assert_eq!(explicit_valence(&smiles, 1), 4);
         assert_eq!(smiles.implicit_hydrogen_counts(), &[0, 0]);
+    }
+
+    /// `explicit_valence` must return the true sum even when it exceeds `u8`.
+    ///
+    /// Before widening to `u16`, this case panicked at parse time on a debug
+    /// `Sum<u8>` overflow when implicit-H counts were computed.
+    #[test]
+    fn explicit_valence_reports_u16_sum_for_high_degree_atoms() {
+        let mut input = alloc::string::String::from("C");
+        for _ in 0..300 {
+            input.push_str("(C)");
+        }
+        let smiles = Smiles::from_str(&input).unwrap();
+        assert_eq!(explicit_valence(&smiles, 0), 300);
     }
 
     #[test]

--- a/src/smiles/mod.rs
+++ b/src/smiles/mod.rs
@@ -547,9 +547,12 @@ impl<AtomPolicy: SmilesAtomPolicy> Smiles<AtomPolicy> {
     /// This is the local RDKit-style count used by this crate:
     /// `degree + explicit hydrogens + implicit hydrogens`.
     ///
+    /// The result saturates at `u8::MAX` for adversarial inputs whose true
+    /// connectivity does not fit into `u8`. Real-chemistry connectivities
+    /// always fit comfortably below the saturation point.
+    ///
     /// # Panics
-    /// Panics if `id` is not a valid atom index in this graph, or if the
-    /// resulting count does not fit into `u8`.
+    /// Panics if `id` is not a valid atom index in this graph.
     ///
     /// # Examples
     ///
@@ -570,9 +573,7 @@ impl<AtomPolicy: SmilesAtomPolicy> Smiles<AtomPolicy> {
             .edge_count_for_node(id)
             .saturating_add(usize::from(atom.hydrogen_count()))
             .saturating_add(usize::from(self.implicit_hydrogen_count(id)));
-        u8::try_from(connectivity).unwrap_or_else(|_| {
-            panic!("connectivity count {connectivity} for atom {id} does not fit into u8")
-        })
+        u8::try_from(connectivity).unwrap_or(u8::MAX)
     }
 
     /// Returns the total valence for the provided atom id.
@@ -580,9 +581,13 @@ impl<AtomPolicy: SmilesAtomPolicy> Smiles<AtomPolicy> {
     /// This is the local RDKit-style total valence used by this crate:
     /// `bond-order sum + explicit hydrogens + implicit hydrogens`.
     ///
+    /// The result saturates at `u8::MAX` for adversarial inputs whose true
+    /// valence does not fit into `u8` (e.g., very high-degree atoms with many
+    /// quadruple bonds). Real-chemistry valences always fit comfortably below
+    /// the saturation point.
+    ///
     /// # Panics
-    /// Panics if `id` is not a valid atom index in this graph, or if the
-    /// resulting valence does not fit into `u8`.
+    /// Panics if `id` is not a valid atom index in this graph.
     ///
     /// # Examples
     ///
@@ -602,9 +607,7 @@ impl<AtomPolicy: SmilesAtomPolicy> Smiles<AtomPolicy> {
         let valence = usize::from(explicit_valence(self, id))
             .saturating_add(usize::from(atom.hydrogen_count()))
             .saturating_add(usize::from(self.implicit_hydrogen_count(id)));
-        u8::try_from(valence).unwrap_or_else(|_| {
-            panic!("total valence {valence} for atom {id} does not fit into u8")
-        })
+        u8::try_from(valence).unwrap_or(u8::MAX)
     }
 
     /// Returns the RDKit-style SMARTS total valence for the provided atom id

--- a/tests/test_smiles_parser.rs
+++ b/tests/test_smiles_parser.rs
@@ -97,3 +97,43 @@ fn test_parse_tribenzo_annulene_variant() {
 fn has_edge(smiles: &Smiles, a: usize, b: usize, bond: Bond) -> bool {
     smiles.edge_for_node_pair((a, b)).is_some_and(|edge| edge.bond() == bond)
 }
+
+/// Adversarial input: a single carbon with 300 single-bond branches.
+///
+/// Before the explicit-valence widening, this panicked during parse via a
+/// debug-mode `Sum<u8>` overflow inside `explicit_valence`. After the fix,
+/// the input must parse and the downstream valence helpers must saturate
+/// instead of panicking.
+#[test]
+fn test_high_degree_single_bond_carbon_does_not_panic() {
+    let mut input = String::from("C");
+    for _ in 0..300 {
+        input.push_str("(C)");
+    }
+
+    let smiles =
+        Smiles::from_str(&input).expect("300-branch carbon must parse, not panic, after widening");
+
+    assert_eq!(smiles.edge_count_for_node(0), 300);
+    assert_eq!(smiles.total_valence(0), u8::MAX);
+    assert_eq!(smiles.connectivity_count(0), u8::MAX);
+}
+
+/// Adversarial input: a single carbon with many quadruple-bond branches.
+///
+/// 64 branches at bond order 4 sum to 256, which overflows `u8` by 1 and
+/// previously panicked during parse. After the fix, parse succeeds and
+/// `total_valence` saturates at `u8::MAX`.
+#[test]
+fn test_high_degree_quadruple_bond_carbon_does_not_panic() {
+    let mut input = String::from("C");
+    for _ in 0..64 {
+        input.push_str("($C)");
+    }
+
+    let smiles = Smiles::from_str(&input)
+        .expect("64 quadruple-bonded neighbors must parse, not panic, after widening");
+
+    assert_eq!(smiles.edge_count_for_node(0), 64);
+    assert_eq!(smiles.total_valence(0), u8::MAX);
+}

--- a/tests/test_square_brackets.rs
+++ b/tests/test_square_brackets.rs
@@ -113,3 +113,37 @@ fn test_hydrogen_hcount_gt_one_stays_invalid() {
     let err = Smiles::from_str("[HH2]").unwrap_err();
     assert_eq!(err.smiles_error(), SmilesError::InvalidHydrogenWithExplicitHydrogensFound);
 }
+
+#[test]
+fn test_bracket_hydrogen_count_at_cap_parses() {
+    let smiles = Smiles::from_str("[CH15]").unwrap_or_else(|_| panic!("Failed to parse [CH15]"));
+
+    assert_eq!(smiles.nodes().len(), 1);
+    assert_eq!(smiles.nodes()[0].hydrogen_count(), 15);
+}
+
+#[test]
+fn test_bracket_hydrogen_count_just_over_cap_is_rejected() {
+    let err = Smiles::from_str("[CH16]").unwrap_err();
+
+    assert_eq!(err.smiles_error(), SmilesError::HydrogenCountOverflow(16));
+}
+
+#[test]
+fn test_bracket_hydrogen_count_far_over_cap_is_rejected() {
+    let err = Smiles::from_str("[HoH254]").unwrap_err();
+
+    assert_eq!(err.smiles_error(), SmilesError::HydrogenCountOverflow(254));
+}
+
+/// Regression test for the bug where bracket atoms with extreme hydrogen
+/// counts parsed successfully and then panicked inside `total_valence` when
+/// `explicit_valence + hydrogen_count + implicit_hydrogen_count` exceeded
+/// the `u8` ceiling.
+#[test]
+fn test_extreme_hydrogen_count_does_not_panic_downstream() {
+    let result = Smiles::from_str("S85II5OINS8[HoH254]9NN9NCC");
+
+    let err = result.expect_err("input with [HoH254] must not parse successfully");
+    assert_eq!(err.smiles_error(), SmilesError::HydrogenCountOverflow(254));
+}


### PR DESCRIPTION
Fixes two reachable panics in u8 valence math.

`"S85II5OINS8[HoH254]9NN9NCC".parse::<Smiles>()` previously parsed successfully and then panicked inside `Smiles::total_valence` with `total valence 257 for atom 7 does not fit into u8`. Bracket H-count above 15 is now rejected at parse time via the new `SmilesError::HydrogenCountOverflow` variant, mirroring the existing charge cap.

`"C" + "(C)".repeat(300)` and `"C" + "($C)".repeat(64)` previously panicked at parse time with `attempt to add with overflow` inside `Sum::sum::<u8>` in `explicit_valence`. That helper now returns `u16`, and `total_valence` / `connectivity_count` saturate at `u8::MAX` instead of panicking.