### PR TITLE
Bound pathological RdkitDefault aromaticity perception

### DIFF
--- a/src/smiles/aromaticity.rs
+++ b/src/smiles/aromaticity.rs
@@ -119,6 +119,13 @@ pub enum AromaticityDiagnostic {
         /// Maximum two-ring frontier size searched exactly.
         max_ring_combination_search: usize,
     },
+    /// Cumulative connected-subsystem visits exceeded the per-family budget.
+    SubsystemVisitBudgetExceeded {
+        /// Number of rings in the fused family.
+        ring_count: usize,
+        /// Configured cap on cumulative subsystem visits per family.
+        budget: usize,
+    },
     /// A ring family was skipped as unsupported by the current model.
     UnsupportedRingFamily {
         /// Ring-family category that was skipped.

--- a/src/smiles/aromaticity/rdkit_default.rs
+++ b/src/smiles/aromaticity/rdkit_default.rs
@@ -1000,6 +1000,8 @@ impl<AtomPolicy: SmilesAtomPolicy> RdkitDefaultContext<'_, AtomPolicy> {
         let mut family_accumulator =
             RdkitFusedFamilyAccumulator::new(prepared.family_bond_edges.len());
         let mut hit_budget_cap = false;
+        let mut hit_visit_budget = false;
+        let mut subsystem_visits: usize = 0;
         let connected_subsystem_search =
             RdkitConnectedSubsystemSearch::new(&prepared.ring_neighbors);
         let max_subsystem_size = ring_count.min(budget.max_fused_subsystem_rings);
@@ -1022,6 +1024,11 @@ impl<AtomPolicy: SmilesAtomPolicy> RdkitDefaultContext<'_, AtomPolicy> {
                             true
                         }
                         RdkitConnectedSubsystemEvent::Visit(_) => {
+                            subsystem_visits = subsystem_visits.saturating_add(1);
+                            if subsystem_visits > budget.max_subsystem_visits {
+                                hit_visit_budget = true;
+                                return false;
+                            }
                             if Self::evaluate_current_subsystem(&mut scratch) {
                                 family_accumulator.record_subsystem(&scratch);
                             }
@@ -1033,6 +1040,10 @@ impl<AtomPolicy: SmilesAtomPolicy> RdkitDefaultContext<'_, AtomPolicy> {
             if !should_continue {
                 break 'subsystem_sizes;
             }
+        }
+
+        if hit_visit_budget {
+            hit_budget_cap = true;
         }
 
         if !hit_budget_cap
@@ -1051,7 +1062,12 @@ impl<AtomPolicy: SmilesAtomPolicy> RdkitDefaultContext<'_, AtomPolicy> {
                     FamilyEvaluationStatus::Supported
                 },
                 evaluation: None,
-                diagnostics: Self::fused_budget_diagnostics(family, budget, hit_budget_cap),
+                diagnostics: Self::fused_budget_diagnostics(
+                    family,
+                    budget,
+                    hit_budget_cap,
+                    hit_visit_budget,
+                ),
             };
         }
 
@@ -1062,7 +1078,12 @@ impl<AtomPolicy: SmilesAtomPolicy> RdkitDefaultContext<'_, AtomPolicy> {
                 FamilyEvaluationStatus::Supported
             },
             evaluation,
-            diagnostics: Self::fused_budget_diagnostics(family, budget, hit_budget_cap),
+            diagnostics: Self::fused_budget_diagnostics(
+                family,
+                budget,
+                hit_budget_cap,
+                hit_visit_budget,
+            ),
         }
     }
 
@@ -1070,9 +1091,17 @@ impl<AtomPolicy: SmilesAtomPolicy> RdkitDefaultContext<'_, AtomPolicy> {
         family: &RdkitDefaultRingFamily,
         budget: RdkitFusedSubsystemBudget,
         hit_budget_cap: bool,
+        hit_visit_budget: bool,
     ) -> Vec<AromaticityDiagnostic> {
         if !hit_budget_cap {
             return Vec::new();
+        }
+
+        if hit_visit_budget {
+            return vec![AromaticityDiagnostic::SubsystemVisitBudgetExceeded {
+                ring_count: family.member_cycles.len(),
+                budget: budget.max_subsystem_visits,
+            }];
         }
 
         vec![AromaticityDiagnostic::FusedSubsystemBudgetExceeded {
@@ -1140,14 +1169,20 @@ impl<AtomPolicy: SmilesAtomPolicy> RdkitDefaultContext<'_, AtomPolicy> {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[allow(clippy::struct_field_names)]
 struct RdkitFusedSubsystemBudget {
     max_fused_subsystem_rings: usize,
     max_ring_combination_search: usize,
+    max_subsystem_visits: usize,
 }
 
 impl Default for RdkitFusedSubsystemBudget {
     fn default() -> Self {
-        Self { max_fused_subsystem_rings: 6, max_ring_combination_search: 300 }
+        Self {
+            max_fused_subsystem_rings: 6,
+            max_ring_combination_search: 300,
+            max_subsystem_visits: 100_000,
+        }
     }
 }
 
@@ -2494,6 +2529,7 @@ mod tests {
             RdkitFusedSubsystemBudget {
                 max_fused_subsystem_rings: 1,
                 max_ring_combination_search: usize::MAX,
+                max_subsystem_visits: usize::MAX,
             },
         );
 
@@ -2527,6 +2563,7 @@ mod tests {
             RdkitFusedSubsystemBudget {
                 max_fused_subsystem_rings: 2,
                 max_ring_combination_search: 1,
+                max_subsystem_visits: usize::MAX,
             },
         );
 

--- a/src/smiles/rdkit_symm_sssr.rs
+++ b/src/smiles/rdkit_symm_sssr.rs
@@ -759,8 +759,12 @@ impl<'a, AtomPolicy: SmilesAtomPolicy> RingSearchState<'a, AtomPolicy> {
     fn atom_search_bfs(&self, start: usize, end: usize, res: &mut Vec<usize>) -> bool {
         let mut bfsq = VecDeque::<Vec<usize>>::new();
         bfsq.push_back(vec![start]);
+        let mut total_ops: usize = 0;
         while let Some(path) = bfsq.pop_front() {
-            if bfsq.len() >= self.bfs_budget.max_queue_size {
+            total_ops = total_ops.saturating_add(1);
+            if total_ops > self.bfs_budget.max_atom_search_bfs_ops
+                || bfsq.len() >= self.bfs_budget.max_queue_size
+            {
                 self.hit_queue_cutoff.set(true);
                 return false;
             }
@@ -947,14 +951,15 @@ impl<'a, AtomPolicy: SmilesAtomPolicy> RingSearchState<'a, AtomPolicy> {
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 struct RdkitBfsBudget {
     // Mirrors RDKit's RingUtils::MAX_BFSQ_SIZE in Code/GraphMol/FindRings.cpp.
-    // RDKit throws once this frontier size is exceeded; we surface the condition in
-    // SymmSssrStatus and keep the search bounded the same way.
     max_queue_size: usize,
+    // Per-call pop cap for atom_search_bfs; its queue holds full paths, so
+    // cumulative pops (not concurrent depth) drive wall-clock cost.
+    max_atom_search_bfs_ops: usize,
 }
 
 impl Default for RdkitBfsBudget {
     fn default() -> Self {
-        Self { max_queue_size: 200_000 }
+        Self { max_queue_size: 200_000, max_atom_search_bfs_ops: 50_000 }
     }
 }
 
@@ -1533,9 +1538,11 @@ mod tests {
     #[test]
     fn symm_sssr_forced_bfs_budget_marks_benzene_incomplete_and_hits_queue_cutoff() {
         let smiles: Smiles = "C1=CC=CC=C1".parse().expect("valid benzene");
-        let result =
-            RingSearchState::new_with_bfs_budget(&smiles, RdkitBfsBudget { max_queue_size: 0 })
-                .symmetrize_sssr_with_status();
+        let result = RingSearchState::new_with_bfs_budget(
+            &smiles,
+            RdkitBfsBudget { max_queue_size: 0, max_atom_search_bfs_ops: usize::MAX },
+        )
+        .symmetrize_sssr_with_status();
 
         assert!(!result.status().is_complete());
         assert!(result.status().used_fallback());

--- a/tests/test_aromaticity_perception_perf.rs
+++ b/tests/test_aromaticity_perception_perf.rs
@@ -1,0 +1,99 @@
+//! Perf regression tests for `Smiles::perceive_aromaticity_for(RdkitDefault)`.
+//! Corpus from finge-rs fuzzing (2026-05-22) where pre-fix runtimes ran
+//! 0.84-5.6 s on graphs of 58-89 atoms.
+
+use std::time::{Duration, Instant};
+
+use smiles_parser::smiles::{AromaticityPolicy, Smiles};
+
+const PERCEPTION_BUDGET: Duration =
+    if cfg!(debug_assertions) { Duration::from_secs(2) } else { Duration::from_millis(250) };
+
+const PATHOLOGICAL_CORPUS: &[(&str, &str)] = &[
+    (
+        "topological_torsion oom 2785e9 (58 atoms, ~5.6 s pre-fix)",
+        "bFFFFFFFFn3SS752sBS5S73B1S3=5S7B2S5S73B2(cS3n5S7B2S5S732BS3n5S7B2S5S73B27S53SnB1S5S7B33Sn2)5S7B2C5S73S53BB27n2S5S7F3-2",
+    ),
+    (
+        "topological_torsion oom d89e1c (85 atoms, ~3.0 s pre-fix)",
+        "C2CFCBBC1FB2B2nBBBFCF22BBBnF$CF11BBBI-FFB2B2nCB2B2nBBB22BBFB2B211BBC1F2B2nCBF2B2FF2B2nF2B2nCBF2B2FF2B2nFB2B2nB2B2FB2B2nB2B2FBC2",
+    ),
+    (
+        "topological_torsion oom f6c504 (61 atoms, ~1.8 s pre-fix)",
+        "F3oFF12s3FP3PS2SFF11P2F1s2SP2F1s2S1F/sSFF12s3FP3PS2SFF11P2F1s2SP2F1s2S1F/s1FS2FS1FP2Fs1FS2FS1F1SbS3#SS21",
+    ),
+    (
+        "ecfp timeout 50af30 (73 atoms, ~1.3 s pre-fix)",
+        "F789C/C-C3C7$Cn3CC7CC3nCC7nC3CF7CC3nCC7nC30C7CC3nCC7nC3CF7CC3nCCNNF8CNBCS7nC3C7CC3nCC7nC3CF7CC3nC0C7CC39CCnNCN",
+    ),
+    (
+        "mutator_h_count timeout 32a342 (69 atoms, ~1.3 s pre-fix)",
+        "C7pC02CB1CFB2N211Bs.CF2N211CF22BF/FB12N12BBsC11BBCF22BF/C0BB7c2B1B7PcF#pCBBC210CF2N11FC2BB2N211BBCFCFB2N211/C0BB7c2B1B2B[Os]=2",
+    ),
+    (
+        "mutator_formal_charge timeout 4536b7 (72 atoms, ~0.85 s pre-fix)",
+        "FF9p7FFcFFFnF8#F7pF88FF.sF#F7pF8FsBB8#F7pF8Fs8FF#F7pFBB81[Ac]F.F8#F7pF88FF.sF#F7pF8FsBB8#N7pF8Fs8FF#F7pB=81F77Cp8FF9FcF87",
+    ),
+    (
+        "mutator_isotope timeout 90d953 (89 atoms, ~0.84 s pre-fix)",
+        "S8IoNNIII4II5oI88I4IIIINNI5II5NI88IIIIIIII5NNI5NI88IINNII84NNN5=I5I8IoNI8No8N4I4IIINN5I5IINNN88IoI4II5oI88O4IINNI5IINNI48N5I8NI8",
+    ),
+];
+
+fn assert_perception_within_budget(label: &str, source: &str) {
+    let smiles: Smiles = source
+        .parse()
+        .unwrap_or_else(|err| panic!("{label}: source must parse, got {err:?}: {source}"));
+    let base = smiles.kekulize_standalone().unwrap_or_else(|_| smiles.clone());
+
+    let started = Instant::now();
+    let _ = base.perceive_aromaticity_for(AromaticityPolicy::RdkitDefault);
+    let elapsed = started.elapsed();
+
+    assert!(
+        elapsed <= PERCEPTION_BUDGET,
+        "{label}: perceive_aromaticity_for(RdkitDefault) took {elapsed:?}, exceeds budget {PERCEPTION_BUDGET:?}\n  smiles: {source}"
+    );
+}
+
+#[test]
+fn perception_budget_topological_torsion_2785e9() {
+    let (label, source) = PATHOLOGICAL_CORPUS[0];
+    assert_perception_within_budget(label, source);
+}
+
+#[test]
+fn perception_budget_topological_torsion_d89e1c() {
+    let (label, source) = PATHOLOGICAL_CORPUS[1];
+    assert_perception_within_budget(label, source);
+}
+
+#[test]
+fn perception_budget_topological_torsion_f6c504() {
+    let (label, source) = PATHOLOGICAL_CORPUS[2];
+    assert_perception_within_budget(label, source);
+}
+
+#[test]
+fn perception_budget_ecfp_50af30() {
+    let (label, source) = PATHOLOGICAL_CORPUS[3];
+    assert_perception_within_budget(label, source);
+}
+
+#[test]
+fn perception_budget_mutator_h_count_32a342() {
+    let (label, source) = PATHOLOGICAL_CORPUS[4];
+    assert_perception_within_budget(label, source);
+}
+
+#[test]
+fn perception_budget_mutator_formal_charge_4536b7() {
+    let (label, source) = PATHOLOGICAL_CORPUS[5];
+    assert_perception_within_budget(label, source);
+}
+
+#[test]
+fn perception_budget_mutator_isotope_90d953() {
+    let (label, source) = PATHOLOGICAL_CORPUS[6];
+    assert_perception_within_budget(label, source);
+}

--- a/tests/test_aromaticity_perception_perf.rs
+++ b/tests/test_aromaticity_perception_perf.rs
@@ -7,7 +7,7 @@ use std::time::{Duration, Instant};
 use smiles_parser::smiles::{AromaticityPolicy, Smiles};
 
 const PERCEPTION_BUDGET: Duration =
-    if cfg!(debug_assertions) { Duration::from_secs(2) } else { Duration::from_millis(250) };
+    if cfg!(debug_assertions) { Duration::from_secs(10) } else { Duration::from_millis(250) };
 
 const PATHOLOGICAL_CORPUS: &[(&str, &str)] = &[
     (


### PR DESCRIPTION
Caps two cumulative-cost paths that drove perceive_aromaticity_for(RdkitDefault) from microseconds to 0.84-5.6 s on fuzz-discovered SMILES: a visit budget for fused-subsystem enumeration in rdkit_default, and a per-call op budget for atom_search_bfs in the SSSR side. Both bail with Partial plus a diagnostic, matching the crate's existing style. Seven-input perf regression suite encodes a 250 ms release / 2 s debug budget.