### PR TITLE
Add MAP4 substructure API

### DIFF
--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -52,9 +52,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "elements_rs"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd188e809697c6ab48177f32792f1d29f41451e7956336b0ba939adfde120aa"
+checksum = "1ee1cc8038a8b7ac1ab9fd940d5a20c99e01defa3bd982057e62017ea4e5402e"
 dependencies = [
  "serde",
  "strum",
@@ -98,7 +98,7 @@ version = "0.1.0"
 source = "git+https://github.com/earth-metabolome-initiative/geometric-traits?branch=main#846307120e95cd25a8dc4fd29b7e91d0e1757ed7"
 dependencies = [
  "bitvec",
- "hashbrown",
+ "hashbrown 0.16.1",
  "lender",
  "multi_ranged",
  "num-traits",
@@ -126,6 +126,16 @@ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
+ "foldhash",
+ "rustc-std-workspace-alloc",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
  "foldhash",
  "rustc-std-workspace-alloc",
 ]
@@ -174,9 +184,9 @@ dependencies = [
 
 [[package]]
 name = "molecular-formulas"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50760a98089095da7db7c128617b704d2e257ac942dd37b44387d138b63c24e"
+checksum = "2157428e33c26e3e5b856371a3be0c2de365d95f968604be07ca05b4bd690adb"
 dependencies = [
  "elements_rs",
  "num-traits",
@@ -302,7 +312,7 @@ version = "0.1.0"
 dependencies = [
  "elements_rs",
  "geometric-traits",
- "hashbrown",
+ "hashbrown 0.17.1",
  "molecular-formulas",
  "smallvec",
  "thiserror",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -34,3 +34,10 @@ path = "fuzz_targets/canonicalization.rs"
 test = false
 doc = false
 bench = false
+
+[[bin]]
+name = "rooted_render"
+path = "fuzz_targets/rooted_render.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/fuzz_targets/rooted_render.rs
+++ b/fuzz/fuzz_targets/rooted_render.rs
@@ -1,0 +1,133 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use smiles_parser::prelude::Smiles;
+
+// Keep this target in the small-molecule regime so fuzz time goes into the
+// invariants rather than a few pathological giant graphs. Rooted rendering
+// canonicalizes once per atom, so the atom cap is a touch lower than the other
+// targets to keep throughput up.
+const MAX_FUZZ_SMILES_BYTES: usize = 256;
+const MAX_FUZZ_ATOMS: usize = 48;
+const MAX_FUZZ_BONDS: usize = 64;
+const MAX_RADIUS: usize = 3;
+
+fn check(data: &str) {
+    if data.len() > MAX_FUZZ_SMILES_BYTES {
+        return;
+    }
+    let Ok(smiles) = data.parse::<Smiles>() else {
+        return;
+    };
+    let node_count = smiles.nodes().len();
+    if node_count == 0 || node_count > MAX_FUZZ_ATOMS || smiles.number_of_bonds() > MAX_FUZZ_BONDS {
+        return;
+    }
+
+    // Baseline is the molecule that the default `render()` round-trips to, not
+    // `canonicalize(original)`. Re-rooting only changes the traversal order, so
+    // it must agree with `render()`. Comparing against the original canonical
+    // form would instead test whether `render()` itself perfectly preserves
+    // stereo, which is a separate (pre-existing) concern.
+    let Ok(rendered_base) = smiles.render().parse::<Smiles>() else {
+        return;
+    };
+    let base_canonical = rendered_base.canonicalize().render();
+
+    for root in 0..node_count {
+        check_rooted_render_preserves_molecule(&smiles, root, &base_canonical);
+        check_canonical_labeling_rooted(&smiles, root, node_count);
+    }
+
+    for center in 0..node_count {
+        for radius in 1..=MAX_RADIUS {
+            check_environment(&smiles, center, radius);
+        }
+    }
+
+    check_non_isomeric(&smiles);
+}
+
+// `render_rooted` only reorders the traversal, so its output must parse back to
+// the same molecule as the default `render()`, and the render must be
+// deterministic.
+fn check_rooted_render_preserves_molecule(smiles: &Smiles, root: usize, base_canonical: &str) {
+    let rooted = smiles.render_rooted(root);
+    assert_eq!(rooted, smiles.render_rooted(root), "render_rooted not deterministic at {root}");
+
+    let reparsed = rooted
+        .parse::<Smiles>()
+        .unwrap_or_else(|err| panic!("rooted render did not parse: {rooted} ({err:?})"));
+    assert_eq!(
+        reparsed.canonicalize().render(),
+        base_canonical,
+        "rooting at {root} changed the molecule: {rooted}"
+    );
+}
+
+// The labeling order is a permutation of all atom ids and contains the root.
+fn check_canonical_labeling_rooted(smiles: &Smiles, root: usize, node_count: usize) {
+    let labeling = smiles.canonical_labeling_rooted(root);
+    let order = labeling.order();
+    let mut seen = order.to_vec();
+    seen.sort_unstable();
+    assert_eq!(seen, (0..node_count).collect::<Vec<usize>>(), "order not a permutation");
+    assert!(order.contains(&root), "root missing from labeling order");
+}
+
+// An environment label is always a valid molecule, is deterministic, and is
+// invariant to the fragment's internal atom numbering (the property MAP4 relies
+// on).
+fn check_environment(smiles: &Smiles, center: usize, radius: usize) {
+    let Some(environment) = smiles.atom_environment(center, radius) else {
+        return;
+    };
+    assert_eq!(environment.center(), center);
+
+    let label = smiles.rooted_environment_smiles(center, radius, false);
+    assert_eq!(
+        label,
+        smiles.rooted_environment_smiles(center, radius, false),
+        "environment label not deterministic at ({center}, {radius})"
+    );
+    if let Some(label) = &label {
+        label
+            .parse::<Smiles>()
+            .unwrap_or_else(|err| panic!("environment label did not parse: {label} ({err:?})"));
+    }
+
+    let atoms: Vec<usize> = environment.atoms().collect();
+    let reversed: Vec<usize> = atoms.iter().rev().copied().collect();
+    let forward = smiles
+        .fragment_from_atoms(atoms)
+        .expect("environment atoms are valid")
+        .render_rooted(center, false)
+        .expect("center is in its environment");
+    let backward = smiles
+        .fragment_from_atoms(reversed)
+        .expect("environment atoms are valid")
+        .render_rooted(center, false)
+        .expect("center is in its environment");
+    assert_eq!(forward, backward, "label depends on numbering at ({center}, {radius})");
+}
+
+// Dropping isomeric features preserves the heavy-atom skeleton, is idempotent,
+// and yields a parseable molecule with no stereo tokens.
+fn check_non_isomeric(smiles: &Smiles) {
+    let plain = smiles.non_isomeric();
+    assert_eq!(plain.nodes().len(), smiles.nodes().len(), "non_isomeric changed atom count");
+
+    let rendered = plain.render();
+    assert!(
+        !rendered.contains('@') && !rendered.contains('/') && !rendered.contains('\\'),
+        "non_isomeric left stereo tokens: {rendered}"
+    );
+    rendered
+        .parse::<Smiles>()
+        .unwrap_or_else(|err| panic!("non_isomeric render did not parse: {rendered} ({err:?})"));
+    assert_eq!(plain.non_isomeric().render(), rendered, "non_isomeric not idempotent");
+}
+
+fuzz_target!(|data: &str| {
+    check(data);
+});

--- a/fuzz/run.sh
+++ b/fuzz/run.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+#
+# Launches the smiles-parser fuzz targets in parallel, one per tmux pane
+# (requires the nightly toolchain, `cargo install cargo-fuzz`, and tmux).
+#
+# Usage:
+#   fuzz/run.sh                      # all targets, 60s each, in a tmux session
+#   fuzz/run.sh rooted_render        # one target
+#   fuzz/run.sh roundtrip canonicalization
+#   MAX_TIME=900 fuzz/run.sh         # 15 minutes per target
+#
+# Environment:
+#   MAX_TIME  seconds per target (default 60)
+#   SESSION   tmux session name (default smiles-fuzz)
+#
+# Each pane runs one target and stays open after it finishes so you can read the
+# final stats. Detach with Ctrl-b d; reattach with `tmux attach -t smiles-fuzz`.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ALL_TARGETS=(
+    roundtrip
+    aromaticity_kekulization_roundtrip
+    canonicalization
+    rooted_render
+)
+
+MAX_TIME="${MAX_TIME:-60}"
+SESSION="${SESSION:-smiles-fuzz}"
+
+if ! command -v tmux >/dev/null 2>&1; then
+    echo "tmux is required but not installed" >&2
+    exit 1
+fi
+
+if [ "$#" -gt 0 ]; then
+    targets=("$@")
+else
+    targets=("${ALL_TARGETS[@]}")
+fi
+
+# Build every target up front so the parallel panes do not race on the cargo
+# build lock when they start (cargo fuzz build takes one target at a time).
+echo "building fuzz targets..."
+for target in "${targets[@]}"; do
+    cargo +nightly fuzz build "$target"
+done
+
+pane_command() {
+    local target="$1"
+    printf 'cargo +nightly fuzz run %q -- -max_total_time=%q -print_final_stats=1; echo; echo "=== %s finished (press enter to close) ==="; read _' \
+        "$target" "$MAX_TIME" "$target"
+}
+
+tmux kill-session -t "$SESSION" 2>/dev/null || true
+pane=$(tmux new-session -d -s "$SESSION" -n fuzz -P -F '#{pane_id}' "$(pane_command "${targets[0]}")")
+tmux select-pane -t "$pane" -T "${targets[0]}"
+for target in "${targets[@]:1}"; do
+    pane=$(tmux split-window -t "$SESSION" -P -F '#{pane_id}' "$(pane_command "$target")")
+    tmux select-pane -t "$pane" -T "$target"
+    tmux select-layout -t "$SESSION" tiled >/dev/null
+done
+tmux select-layout -t "$SESSION" tiled >/dev/null
+
+# Label each pane with its harness name along the pane border.
+tmux set-option -t "$SESSION" pane-border-status top
+tmux set-option -t "$SESSION" pane-border-format ' #{pane_title} '
+
+echo "started ${#targets[@]} target(s) in tmux session '$SESSION' for ${MAX_TIME}s each"
+tmux attach -t "$SESSION"

--- a/src/atom/mod.rs
+++ b/src/atom/mod.rs
@@ -472,6 +472,32 @@ impl Atom {
         self.chirality
     }
 
+    /// Returns a copy with isomeric features (isotope label and tetrahedral
+    /// chirality) cleared.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use elements_rs::Element;
+    /// use smiles_parser::atom::{Atom, atom_symbol::AtomSymbol, bracketed::chirality::Chirality};
+    ///
+    /// let atom = Atom::builder()
+    ///     .with_symbol(AtomSymbol::Element(Element::C))
+    ///     .with_isotope(13)
+    ///     .with_chirality(Chirality::At)
+    ///     .build()
+    ///     .non_isomeric();
+    /// assert_eq!(atom.isotope_mass_number(), None);
+    /// assert_eq!(atom.chirality(), None);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn non_isomeric(mut self) -> Self {
+        self.isotope_mass_number = None;
+        self.chirality = None;
+        self
+    }
+
     #[cfg(test)]
     #[inline]
     #[must_use]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -276,6 +276,28 @@ impl fmt::Display for SmilesErrorWithSpan {
     }
 }
 
+/// Error returned when carving a [`Fragment`](crate::smiles::Fragment) out of a
+/// parent graph fails.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Error)]
+#[non_exhaustive]
+pub enum SubgraphError {
+    /// An atom id in the input is not a valid atom of the parent graph.
+    #[error("Atom id {0} is out of range for the parent graph")]
+    AtomOutOfRange(usize),
+    /// A bond in the input references an atom that is not part of the fragment.
+    #[error("Bond references atom {0}, which is not in the fragment")]
+    BondReferencesUnknownAtom(usize),
+}
+
+/// Error returned when rendering a fragment anchored at a chosen parent atom.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Error)]
+#[non_exhaustive]
+pub enum RootError {
+    /// The requested root atom is not part of the fragment.
+    #[error("Atom {0} is not in the fragment")]
+    AtomNotInFragment(usize),
+}
+
 #[cfg(test)]
 mod tests {
     use alloc::string::ToString;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,15 +29,15 @@ pub use crate::datasets::{
     default_dataset_cache_dir,
 };
 pub use crate::{
-    errors::{SmilesError, SmilesErrorWithSpan},
+    errors::{RootError, SmilesError, SmilesErrorWithSpan, SubgraphError},
     smiles::{
         AromaticityAssignment, AromaticityAssignmentApplicationError, AromaticityDiagnostic,
         AromaticityModel, AromaticityPerception, AromaticityPolicy, AromaticityRingFamilyKind,
-        AromaticityStatus, DoubleBondStereoConfig, KekulizationError, KekulizationMode,
-        RdkitDefaultAromaticity, RdkitMdlAromaticity, RdkitSimpleAromaticity, RingAtomMembership,
-        RingAtomMembershipScratch, RingMembership, Smiles, SmilesComponents, SymmSssrResult,
-        SymmSssrStatus, WildcardAromaticityPerception, WildcardMolecularFormulaConversionError,
-        WildcardSmiles, WildcardSmilesComponents,
+        AromaticityStatus, AtomEnvironment, DoubleBondStereoConfig, Fragment, KekulizationError,
+        KekulizationMode, RdkitDefaultAromaticity, RdkitMdlAromaticity, RdkitSimpleAromaticity,
+        RingAtomMembership, RingAtomMembershipScratch, RingMembership, Smiles, SmilesComponents,
+        SymmSssrResult, SymmSssrStatus, WildcardAromaticityPerception,
+        WildcardMolecularFormulaConversionError, WildcardSmiles, WildcardSmilesComponents,
     },
 };
 
@@ -46,11 +46,12 @@ pub mod prelude {
     pub use crate::{
         AromaticityAssignment, AromaticityAssignmentApplicationError, AromaticityDiagnostic,
         AromaticityModel, AromaticityPerception, AromaticityPolicy, AromaticityRingFamilyKind,
-        AromaticityStatus, DoubleBondStereoConfig, KekulizationError, KekulizationMode,
-        RdkitDefaultAromaticity, RdkitMdlAromaticity, RdkitSimpleAromaticity, RingAtomMembership,
-        RingAtomMembershipScratch, RingMembership, Smiles, SmilesComponents, SmilesError,
-        SmilesErrorWithSpan, SymmSssrResult, SymmSssrStatus, WildcardAromaticityPerception,
-        WildcardMolecularFormulaConversionError, WildcardSmiles, WildcardSmilesComponents,
+        AromaticityStatus, AtomEnvironment, DoubleBondStereoConfig, Fragment, KekulizationError,
+        KekulizationMode, RdkitDefaultAromaticity, RdkitMdlAromaticity, RdkitSimpleAromaticity,
+        RingAtomMembership, RingAtomMembershipScratch, RingMembership, RootError, Smiles,
+        SmilesComponents, SmilesError, SmilesErrorWithSpan, SubgraphError, SymmSssrResult,
+        SymmSssrStatus, WildcardAromaticityPerception, WildcardMolecularFormulaConversionError,
+        WildcardSmiles, WildcardSmilesComponents,
     };
     #[cfg(feature = "datasets")]
     pub use crate::{

--- a/src/smiles/atom_environment.rs
+++ b/src/smiles/atom_environment.rs
@@ -1,0 +1,225 @@
+//! Radius-N circular atom environments, matching RDKit's
+//! `FindAtomEnvironmentOfRadiusN`.
+//!
+//! The environment of radius `r` around an atom is the cumulative set of bonds
+//! reachable within `r` bonds, grown shell by shell. Following RDKit, the
+//! environment is *empty* (returned as `None`) when the outermost requested
+//! shell adds no new bond, e.g. when the center's eccentricity is below `r` or
+//! the center has no incident bonds at all. Ring-closure bonds between two
+//! atoms that fall in the same shell are included, so a benzene environment
+//! renders as a ring rather than a chain.
+
+use alloc::{string::String, vec::Vec};
+
+use geometric_traits::traits::SparseMatrix2D;
+
+use super::{ConcreteAtoms, Fragment, Smiles, SmilesAtomPolicy};
+use crate::{bond::bond_edge::BondEdge, errors::SubgraphError};
+
+/// A borrowed view of the radius-N circular environment of an atom. Always
+/// non-empty and always knows its own center.
+#[derive(Debug, Clone)]
+pub struct AtomEnvironment<'mol, AtomPolicy = ConcreteAtoms> {
+    parent: &'mol Smiles<AtomPolicy>,
+    center: usize,
+    atoms: Vec<usize>,
+    bonds: Vec<BondEdge>,
+}
+
+impl<AtomPolicy: SmilesAtomPolicy> AtomEnvironment<'_, AtomPolicy> {
+    /// Returns the center atom id (in parent coordinates).
+    #[inline]
+    #[must_use]
+    pub fn center(&self) -> usize {
+        self.center
+    }
+
+    /// Returns the number of atoms in the environment.
+    #[inline]
+    #[must_use]
+    pub fn atom_count(&self) -> usize {
+        self.atoms.len()
+    }
+
+    /// Returns the number of bonds in the environment.
+    #[inline]
+    #[must_use]
+    pub fn bond_count(&self) -> usize {
+        self.bonds.len()
+    }
+
+    /// Returns whether a parent atom id is part of the environment.
+    #[must_use]
+    pub fn contains_atom(&self, atom_id: usize) -> bool {
+        self.atoms.contains(&atom_id)
+    }
+
+    /// Iterates the parent atom ids in the environment.
+    pub fn atoms(&self) -> impl Iterator<Item = usize> + '_ {
+        self.atoms.iter().copied()
+    }
+
+    /// Iterates the bonds in the environment.
+    pub fn bonds(&self) -> impl Iterator<Item = BondEdge> + '_ {
+        self.bonds.iter().copied()
+    }
+
+    /// Materializes the environment as a standalone [`Fragment`].
+    ///
+    /// # Errors
+    ///
+    /// Propagates any [`SubgraphError`] from fragment construction.
+    pub fn to_fragment(&self) -> Result<Fragment<AtomPolicy>, SubgraphError> {
+        self.parent.fragment_from_bonds(self.bonds.iter().copied())
+    }
+
+    /// Renders the environment as a SMILES label rooted at its center. When
+    /// `isomeric` is false, isotopes and stereochemistry are dropped (the MAP4
+    /// setting).
+    ///
+    /// # Errors
+    ///
+    /// Propagates any [`SubgraphError`] from fragment construction.
+    pub fn rooted_smiles(&self, isomeric: bool) -> Result<String, SubgraphError> {
+        let fragment = self.to_fragment()?;
+        Ok(fragment
+            .render_rooted(self.center, isomeric)
+            .unwrap_or_else(|_| unreachable!("the center always belongs to its own environment")))
+    }
+}
+
+impl<AtomPolicy: SmilesAtomPolicy> Smiles<AtomPolicy> {
+    /// Returns the radius-`radius` circular environment of `center`, or `None`
+    /// for the empty-shell case (RDKit `FindAtomEnvironmentOfRadiusN`).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `center` is not a valid atom id.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use smiles_parser::prelude::Smiles;
+    ///
+    /// let mol: Smiles = "CCO".parse()?;
+    /// assert!(mol.atom_environment(1, 2).is_none()); // central C, eccentricity 1 < 2
+    /// let env = mol.atom_environment(0, 2).unwrap();
+    /// assert_eq!(env.center(), 0);
+    /// assert_eq!(env.atom_count(), 3);
+    /// # Ok::<(), smiles_parser::SmilesErrorWithSpan>(())
+    /// ```
+    #[must_use]
+    pub fn atom_environment(
+        &self,
+        center: usize,
+        radius: usize,
+    ) -> Option<AtomEnvironment<'_, AtomPolicy>> {
+        assert!(center < self.nodes().len(), "atom_environment: center {center} is out of range");
+        let (atoms, bonds) = self.grow_radius_environment(center, radius)?;
+        Some(AtomEnvironment { parent: self, center, atoms, bonds })
+    }
+
+    /// Grows the radius-`radius` environment shell by shell, returning its
+    /// atoms and bonds, or `None` if the outermost requested shell adds
+    /// nothing.
+    fn grow_radius_environment(
+        &self,
+        center: usize,
+        radius: usize,
+    ) -> Option<(Vec<usize>, Vec<BondEdge>)> {
+        if radius == 0 {
+            return None;
+        }
+
+        let mut atom_layer = vec![usize::MAX; self.nodes().len()];
+        atom_layer[center] = 0;
+        let mut atoms = vec![center];
+        let mut bonds: Vec<BondEdge> = Vec::new();
+        let mut frontier = vec![center];
+
+        for layer in 1..=radius {
+            let mut next_frontier = Vec::new();
+            let mut bonds_this_layer = 0;
+            for &source in &frontier {
+                for target in self.bond_matrix.sparse_row(source) {
+                    if !self.record_environment_bond(
+                        source,
+                        target,
+                        layer,
+                        &mut atom_layer,
+                        &mut atoms,
+                        &mut next_frontier,
+                        &mut bonds,
+                    ) {
+                        continue;
+                    }
+                    bonds_this_layer += 1;
+                }
+            }
+            if bonds_this_layer == 0 {
+                return None;
+            }
+            frontier = next_frontier;
+            if frontier.is_empty() && layer < radius {
+                return None;
+            }
+        }
+
+        Some((atoms, bonds))
+    }
+
+    /// Classifies one frontier edge and, if it belongs to this shell, records
+    /// it (and any newly reached atom). Returns whether a bond was added.
+    #[allow(clippy::too_many_arguments)]
+    fn record_environment_bond(
+        &self,
+        source: usize,
+        target: usize,
+        layer: usize,
+        atom_layer: &mut [usize],
+        atoms: &mut Vec<usize>,
+        next_frontier: &mut Vec<usize>,
+        bonds: &mut Vec<BondEdge>,
+    ) -> bool {
+        let target_layer = atom_layer[target];
+        let add_bond = if target_layer == usize::MAX {
+            atom_layer[target] = layer;
+            next_frontier.push(target);
+            atoms.push(target);
+            true
+        } else if target_layer == layer {
+            // Discovered earlier in this same shell by another atom.
+            true
+        } else if target_layer == layer - 1 {
+            // Ring closure within the current frontier, recorded once.
+            source < target
+        } else {
+            // Already recorded in an earlier shell.
+            false
+        };
+        if add_bond {
+            bonds.push(
+                self.edge_for_node_pair((source, target))
+                    .unwrap_or_else(|| unreachable!("iterated edge must exist")),
+            );
+        }
+        add_bond
+    }
+
+    /// One-shot MAP4 substructure label: environment to fragment to rooted
+    /// render. Returns `None` for the empty-shell case and for any fragment
+    /// construction failure (both map to MAP4's empty label).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `center` is not a valid atom id.
+    #[must_use]
+    pub fn rooted_environment_smiles(
+        &self,
+        center: usize,
+        radius: usize,
+        isomeric: bool,
+    ) -> Option<String> {
+        self.atom_environment(center, radius)?.rooted_smiles(isomeric).ok()
+    }
+}

--- a/src/smiles/canonicalization.rs
+++ b/src/smiles/canonicalization.rs
@@ -43,6 +43,10 @@ impl SmilesCanonicalLabeling {
         Self { order, new_index_of_old_node }
     }
 
+    pub(crate) fn from_order(order: Vec<usize>) -> Self {
+        Self::new(order)
+    }
+
     /// Returns original node ids in canonical order.
     ///
     /// # Examples

--- a/src/smiles/emitter.rs
+++ b/src/smiles/emitter.rs
@@ -15,6 +15,16 @@ pub(crate) fn emit<AtomPolicy: SmilesAtomPolicy>(smiles: &Smiles<AtomPolicy>) ->
     emit_with_plan(smiles, &plan)
 }
 
+/// Renders `smiles` with one component's traversal forced to start at `root`.
+#[must_use]
+pub(crate) fn emit_rooted<AtomPolicy: SmilesAtomPolicy>(
+    smiles: &Smiles<AtomPolicy>,
+    root: usize,
+) -> String {
+    let plan = smiles.render_plan_with_root(Some(root));
+    emit_with_plan(smiles, &plan)
+}
+
 /// Emits a SMILES string from a completed render plan.
 ///
 /// No graph search or ordering work happens here. The emitter only walks

--- a/src/smiles/fragment.rs
+++ b/src/smiles/fragment.rs
@@ -1,0 +1,199 @@
+//! Standalone fragments carved out of a parent [`Smiles`] graph.
+//!
+//! A [`Fragment`] keeps the parent's atom and bond typing (including aromatic
+//! flags) but recomputes implicit hydrogen counts for the fragment's own
+//! connectivity, so an atom that becomes terminal gains the hydrogens its
+//! reduced valence implies. Atom ids are remapped to a compact local numbering,
+//! with the parent correspondence kept private behind [`Fragment::local_id`]
+//! and [`Fragment::parent_id`].
+
+use alloc::{string::String, vec::Vec};
+
+use geometric_traits::traits::SparseValuedMatrixRef;
+
+use super::{BondMatrixBuilder, ConcreteAtoms, Smiles, SmilesAtomPolicy};
+use crate::{
+    bond::bond_edge::BondEdge,
+    errors::{RootError, SubgraphError},
+};
+
+/// A standalone molecule carved out of a parent graph, with a private mapping
+/// back to the parent's atom ids.
+#[derive(Debug, Clone)]
+pub struct Fragment<AtomPolicy = ConcreteAtoms> {
+    smiles: Smiles<AtomPolicy>,
+    parent_of_local: Vec<usize>,
+    local_of_parent: Vec<usize>,
+}
+
+impl<AtomPolicy: SmilesAtomPolicy> Fragment<AtomPolicy> {
+    /// Returns the fragment as a standalone [`Smiles`].
+    #[inline]
+    #[must_use]
+    pub fn smiles(&self) -> &Smiles<AtomPolicy> {
+        &self.smiles
+    }
+
+    /// Consumes the fragment and returns the standalone [`Smiles`].
+    #[inline]
+    #[must_use]
+    pub fn into_smiles(self) -> Smiles<AtomPolicy> {
+        self.smiles
+    }
+
+    /// Returns the number of atoms in the fragment.
+    #[inline]
+    #[must_use]
+    pub fn atom_count(&self) -> usize {
+        self.parent_of_local.len()
+    }
+
+    /// Returns the fragment-local id of a parent atom, if it is in the
+    /// fragment.
+    #[inline]
+    #[must_use]
+    pub fn local_id(&self, parent_atom: usize) -> Option<usize> {
+        self.local_of_parent.get(parent_atom).copied().filter(|&local| local != usize::MAX)
+    }
+
+    /// Returns the parent id of a fragment atom.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `local_atom` is not a valid fragment atom id.
+    #[inline]
+    #[must_use]
+    pub fn parent_id(&self, local_atom: usize) -> usize {
+        self.parent_of_local[local_atom]
+    }
+
+    /// Renders the fragment anchored at a parent atom. When `isomeric` is
+    /// false, isotopes and stereochemistry are dropped (RDKit
+    /// `isomericSmiles=False`).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RootError::AtomNotInFragment`] if `parent_atom` is not part of
+    /// the fragment.
+    pub fn render_rooted(&self, parent_atom: usize, isomeric: bool) -> Result<String, RootError> {
+        let local = self.local_id(parent_atom).ok_or(RootError::AtomNotInFragment(parent_atom))?;
+        if isomeric {
+            Ok(self.smiles.render_rooted(local))
+        } else {
+            Ok(self.smiles.non_isomeric().render_rooted(local))
+        }
+    }
+}
+
+impl<AtomPolicy: SmilesAtomPolicy> Smiles<AtomPolicy> {
+    /// Builds a fragment from an atom set: every bond among the chosen atoms is
+    /// included (an induced subgraph). Implicit hydrogen counts are recomputed
+    /// for the fragment.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SubgraphError::AtomOutOfRange`] if any id is not a valid atom.
+    pub fn fragment_from_atoms(
+        &self,
+        atoms: impl IntoIterator<Item = usize>,
+    ) -> Result<Fragment<AtomPolicy>, SubgraphError> {
+        let node_count = self.nodes().len();
+        let mut parent_of_local = Vec::new();
+        let mut local_of_parent = vec![usize::MAX; node_count];
+        for atom in atoms {
+            if atom >= node_count {
+                return Err(SubgraphError::AtomOutOfRange(atom));
+            }
+            register_local(&mut parent_of_local, &mut local_of_parent, atom);
+        }
+
+        let mut builder = BondMatrixBuilder::default();
+        for ((row, column), entry) in self.bond_matrix.sparse_entries() {
+            if row >= column {
+                continue;
+            }
+            let (local_row, local_column) = (local_of_parent[row], local_of_parent[column]);
+            if local_row == usize::MAX || local_column == usize::MAX {
+                continue;
+            }
+            builder
+                .push_edge_with_descriptor(local_row, local_column, entry.descriptor(), None)
+                .unwrap_or_else(|_| unreachable!("induced fragment preserves a simple graph"));
+        }
+
+        Ok(self.finish_fragment(parent_of_local, local_of_parent, builder))
+    }
+
+    /// Builds a fragment from a bond set (RDKit `PathToSubmol`): exactly the
+    /// listed bonds are kept and their endpoints become the fragment's atoms.
+    /// Implicit hydrogen counts are recomputed for the fragment.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SubgraphError::AtomOutOfRange`] if an endpoint is not a valid
+    /// atom, or [`SubgraphError::BondReferencesUnknownAtom`] if a listed bond
+    /// is not an edge of the parent graph.
+    pub fn fragment_from_bonds(
+        &self,
+        bonds: impl IntoIterator<Item = BondEdge>,
+    ) -> Result<Fragment<AtomPolicy>, SubgraphError> {
+        let node_count = self.nodes().len();
+        let mut parent_of_local = Vec::new();
+        let mut local_of_parent = vec![usize::MAX; node_count];
+        let mut builder = BondMatrixBuilder::default();
+        for edge in bonds {
+            let [source, target] = edge.endpoints();
+            if source >= node_count {
+                return Err(SubgraphError::AtomOutOfRange(source));
+            }
+            if target >= node_count {
+                return Err(SubgraphError::AtomOutOfRange(target));
+            }
+            let descriptor = self
+                .edge_for_node_pair((source, target))
+                .ok_or(SubgraphError::BondReferencesUnknownAtom(target))?
+                .descriptor();
+            let local_source = register_local(&mut parent_of_local, &mut local_of_parent, source);
+            let local_target = register_local(&mut parent_of_local, &mut local_of_parent, target);
+            builder
+                .push_edge_with_descriptor(local_source, local_target, descriptor, None)
+                .map_err(|_| SubgraphError::BondReferencesUnknownAtom(target))?;
+        }
+
+        Ok(self.finish_fragment(parent_of_local, local_of_parent, builder))
+    }
+
+    fn finish_fragment(
+        &self,
+        parent_of_local: Vec<usize>,
+        local_of_parent: Vec<usize>,
+        builder: BondMatrixBuilder,
+    ) -> Fragment<AtomPolicy> {
+        let atom_nodes: Vec<_> =
+            parent_of_local.iter().map(|&parent| self.atom_nodes[parent]).collect();
+        let atom_count = atom_nodes.len();
+        let parsed_stereo_neighbors = vec![Vec::new(); atom_count];
+        let smiles = Self::from_bond_matrix_parts_with_parsed_stereo_and_source(
+            atom_nodes,
+            builder.finish(atom_count),
+            parsed_stereo_neighbors,
+            None,
+        );
+        Fragment { smiles, parent_of_local, local_of_parent }
+    }
+}
+
+/// Assigns (or returns) the local id of a parent atom, recording it on first
+/// sight.
+fn register_local(
+    parent_of_local: &mut Vec<usize>,
+    local_of_parent: &mut [usize],
+    parent_atom: usize,
+) -> usize {
+    let local = &mut local_of_parent[parent_atom];
+    if *local == usize::MAX {
+        *local = parent_of_local.len();
+        parent_of_local.push(parent_atom);
+    }
+    *local
+}

--- a/src/smiles/mod.rs
+++ b/src/smiles/mod.rs
@@ -36,11 +36,13 @@ use crate::{
 };
 
 mod aromaticity;
+mod atom_environment;
 mod branches;
 mod canonicalization;
 mod connected_components;
 mod double_bond_stereo;
 mod emitter;
+mod fragment;
 mod from_str;
 mod geometric_traits_impl;
 mod implicit_hydrogens;
@@ -64,9 +66,11 @@ pub use self::{
         AromaticityStatus, RdkitDefaultAromaticity, RdkitMdlAromaticity, RdkitSimpleAromaticity,
         WildcardAromaticityPerception,
     },
+    atom_environment::AtomEnvironment,
     canonicalization::SmilesCanonicalLabeling,
     connected_components::{SmilesComponents, WildcardSmilesComponents},
     double_bond_stereo::DoubleBondStereoConfig,
+    fragment::Fragment,
     geometric_traits_impl::{BondEntry, BondMatrix},
     kekulization::{KekulizationError, KekulizationMode},
     molecular_formula::WildcardMolecularFormulaConversionError,
@@ -1157,6 +1161,90 @@ impl<AtomPolicy: SmilesAtomPolicy> Smiles<AtomPolicy> {
     #[must_use]
     pub fn render(&self) -> String {
         self::emitter::emit(self)
+    }
+
+    /// Renders this graph as SMILES with the traversal forced to start at
+    /// `root`.
+    ///
+    /// All ordering decisions other than the root are identical to
+    /// [`render`](Self::render), so the output is deterministic and parses back
+    /// to the same molecule. Only the connected component containing `root` is
+    /// re-rooted, leaving any other components on their chosen roots.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `root` is not a valid atom id.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use smiles_parser::prelude::Smiles;
+    ///
+    /// let smiles: Smiles = "CCO".parse()?;
+    /// assert!(smiles.render_rooted(2).starts_with('O'));
+    /// # Ok::<(), smiles_parser::SmilesErrorWithSpan>(())
+    /// ```
+    #[must_use]
+    pub fn render_rooted(&self, root: usize) -> String {
+        assert!(root < self.nodes().len(), "render_rooted: root {root} is out of range");
+        self::emitter::emit_rooted(self, root)
+    }
+
+    /// Returns the traversal order used by
+    /// [`render_rooted`](Self::render_rooted) as a [`SmilesCanonicalLabeling`].
+    /// For a connected graph this places `root` at ordinal 0. When the graph
+    /// has several components, `root` leads its own component's run and the
+    /// components keep their render order.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `root` is not a valid atom id.
+    #[must_use]
+    pub fn canonical_labeling_rooted(&self, root: usize) -> SmilesCanonicalLabeling {
+        assert!(root < self.nodes().len(), "canonical_labeling_rooted: root {root} out of range");
+        let order = self.render_plan_with_root(Some(root)).traversal_order();
+        SmilesCanonicalLabeling::from_order(order)
+    }
+
+    /// Returns a copy with isomeric features removed: isotope labels and
+    /// tetrahedral chirality are cleared on every atom, and directional
+    /// (double-bond stereo) bonds are flattened to plain bonds. Implicit
+    /// hydrogen counts are recomputed for the result.
+    ///
+    /// This mirrors RDKit's `isomericSmiles=False`: two graphs that differ only
+    /// in stereochemistry or isotope labeling collapse to the same molecule.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use smiles_parser::prelude::Smiles;
+    ///
+    /// let labeled: Smiles = "[13CH3]O".parse()?;
+    /// let plain: Smiles = "[12CH3]O".parse()?;
+    /// assert_eq!(labeled.non_isomeric().render(), plain.non_isomeric().render());
+    /// # Ok::<(), smiles_parser::SmilesErrorWithSpan>(())
+    /// ```
+    #[must_use]
+    pub fn non_isomeric(&self) -> Self {
+        let atom_nodes: Vec<_> = self.atom_nodes.iter().map(|atom| atom.non_isomeric()).collect();
+        let mut builder = crate::smiles::BondMatrixBuilder::default();
+        for ((row, column), entry) in self.bond_matrix.sparse_entries() {
+            if row >= column {
+                continue;
+            }
+            let descriptor = entry.descriptor();
+            let flattened = descriptor.with_bond(descriptor.bond().without_direction());
+            builder
+                .push_edge_with_descriptor(row, column, flattened, None)
+                .unwrap_or_else(|_| unreachable!("non-isomeric copy preserves a simple graph"));
+        }
+        let parsed_stereo_neighbors = vec![Vec::new(); atom_nodes.len()];
+        Self::from_bond_matrix_parts_with_parsed_stereo_and_source(
+            atom_nodes,
+            builder.finish(self.atom_nodes.len()),
+            parsed_stereo_neighbors,
+            None,
+        )
     }
 
     fn ring_membership_with_packed_bridge_keys(&self, bond_count: usize) -> RingMembership {

--- a/src/smiles/render_plan.rs
+++ b/src/smiles/render_plan.rs
@@ -35,6 +35,14 @@ impl RenderPlan {
         self.nodes.get(node_id)
     }
 
+    /// Returns all node ids in final traversal order (components concatenated
+    /// in output order, each in preorder). Each component root is first in
+    /// its run.
+    #[must_use]
+    pub(crate) fn traversal_order(&self) -> Vec<usize> {
+        self.components.iter().flat_map(|component| component.preorder.iter().copied()).collect()
+    }
+
     /// Estimates the final rendered length from the completed plan.
     ///
     /// This is used only to pre-size the output buffer. It mirrors the final
@@ -272,12 +280,35 @@ impl<AtomPolicy: crate::smiles::SmilesAtomPolicy> Smiles<AtomPolicy> {
     /// proof that the final plan will always stay below `100`.
     #[must_use]
     pub(crate) fn render_plan(&self) -> RenderPlan {
+        self.render_plan_with_root(None)
+    }
+
+    /// Replaces the chosen root of `forced`'s connected component with
+    /// `forced`, leaving the roots of other components untouched.
+    fn force_component_root(&self, roots: &mut [usize], forced: usize) {
+        let components = self.connected_components();
+        let target = components.component_of_node(forced);
+        for root in roots.iter_mut() {
+            if components.component_of_node(*root) == target {
+                *root = forced;
+                break;
+            }
+        }
+    }
+
+    /// Builds a render plan, optionally forcing the traversal of one connected
+    /// component to start at `forced_root`. Other components keep their
+    /// deterministically chosen roots.
+    pub(crate) fn render_plan_with_root(&self, forced_root: Option<usize>) -> RenderPlan {
         let node_count = self.nodes().len();
         let invariants = self.atom_invariants();
         let refined = self.refined_atom_classes_from_invariants(&invariants);
         let refined_classes = refined.classes().to_vec();
         let rooted_classes = self.rooted_symmetry_classes_from_refined(&refined_classes);
-        let roots = self.component_roots_from_planning(&invariants, &rooted_classes);
+        let mut roots = self.component_roots_from_planning(&invariants, &rooted_classes);
+        if let Some(forced) = forced_root {
+            self.force_component_root(&mut roots, forced);
+        }
         let primary = build_render_ordering(
             self,
             self.spanning_forest_with_planning(

--- a/tests/test_atom_environment.rs
+++ b/tests/test_atom_environment.rs
@@ -1,0 +1,99 @@
+//! Radius-N atom environment tests (RDKit FindAtomEnvironmentOfRadiusN).
+use smiles_parser::prelude::Smiles;
+
+fn canon(s: &str) -> String {
+    s.parse::<Smiles>().unwrap().canonicalize().render()
+}
+
+#[test]
+fn empty_shell_rule() {
+    let ethanol: Smiles = "CCO".parse().unwrap();
+    assert!(ethanol.atom_environment(1, 2).is_none()); // central C, eccentricity 1 < 2
+    assert!("CC(=O)O".parse::<Smiles>().unwrap().atom_environment(1, 2).is_none()); // carbonyl
+    assert!("C".parse::<Smiles>().unwrap().atom_environment(0, 1).is_none()); // methane
+    assert!("[NH4+]".parse::<Smiles>().unwrap().atom_environment(0, 1).is_none());
+    assert!(ethanol.atom_environment(0, 0).is_none()); // radius 0
+}
+
+#[test]
+fn terminal_carbon_radius_two() {
+    let m: Smiles = "CCO".parse().unwrap();
+    let env = m.atom_environment(0, 2).unwrap();
+    assert_eq!(env.center(), 0);
+    assert_eq!(env.atom_count(), 3);
+    assert_eq!(env.bond_count(), 2);
+    assert!(env.contains_atom(0) && env.contains_atom(1) && env.contains_atom(2));
+    assert_eq!(canon(&env.rooted_smiles(false).unwrap()), canon("CCO"));
+}
+
+#[test]
+fn central_carbon_radius_one_is_non_empty() {
+    let m: Smiles = "CC(=O)O".parse().unwrap();
+    let env = m.atom_environment(1, 1).unwrap();
+    assert_eq!(env.center(), 1);
+    assert_eq!(env.bond_count(), 3);
+}
+
+#[test]
+fn benzene_radius_two_is_a_path() {
+    let m: Smiles = "c1ccccc1".parse().unwrap();
+    let env = m.atom_environment(0, 2).unwrap();
+    assert_eq!(env.atom_count(), 5);
+    assert_eq!(env.bond_count(), 4);
+}
+
+#[test]
+fn benzene_radius_three_closes_the_ring() {
+    let m: Smiles = "c1ccccc1".parse().unwrap();
+    let env = m.atom_environment(0, 3).unwrap();
+    assert_eq!(env.atom_count(), 6);
+    assert_eq!(env.bond_count(), 6); // ring-closure bond included
+    assert_eq!(canon(&env.rooted_smiles(false).unwrap()), canon("c1ccccc1"));
+}
+
+#[test]
+fn to_fragment_is_centered() {
+    let m: Smiles = "CCO".parse().unwrap();
+    let env = m.atom_environment(0, 2).unwrap();
+    let frag = env.to_fragment().unwrap();
+    assert_eq!(frag.atom_count(), 3);
+    assert_eq!(frag.local_id(0), Some(0));
+}
+
+#[test]
+fn iterators_agree_with_counts() {
+    let m: Smiles = "c1ccccc1".parse().unwrap();
+    let env = m.atom_environment(0, 2).unwrap();
+    assert_eq!(env.atoms().count(), env.atom_count());
+    assert_eq!(env.bonds().count(), env.bond_count());
+}
+
+#[test]
+fn small_ring_radius_two_closes_via_frontier_bond() {
+    // Cyclopropane: at radius 2 the two radius-1 neighbors close the ring.
+    let m: Smiles = "C1CC1".parse().unwrap();
+    let env = m.atom_environment(0, 2).unwrap();
+    assert_eq!(env.atom_count(), 3);
+    assert_eq!(env.bond_count(), 3);
+}
+
+#[test]
+fn radius_beyond_eccentricity_is_empty() {
+    // Cyclopropane has eccentricity 1, so radius 3 exhausts the frontier early.
+    let m: Smiles = "C1CC1".parse().unwrap();
+    assert!(m.atom_environment(0, 3).is_none());
+}
+
+#[test]
+fn toluene_labels_match_rdkit_reference() {
+    // Semantic parity with the RDKit MAP4 reference strings from the proposal.
+    let m: Smiles = "Cc1ccccc1".parse().unwrap();
+    assert_eq!(m.rooted_environment_smiles(0, 1, false).unwrap(), "Cc");
+    assert_eq!(m.rooted_environment_smiles(1, 2, false).unwrap(), "c(C)(cc)cc");
+}
+
+#[test]
+#[should_panic(expected = "center")]
+fn panics_on_out_of_range_center() {
+    let _ = "CCO".parse::<Smiles>().unwrap().atom_environment(99, 1);
+}

--- a/tests/test_fragment.rs
+++ b/tests/test_fragment.rs
@@ -1,0 +1,116 @@
+//! Fragment construction tests.
+use smiles_parser::{
+    bond::{Bond, bond_edge::bond_edge},
+    prelude::{Smiles, SubgraphError},
+};
+
+#[test]
+fn from_atoms_recomputes_hydrogens() {
+    let m: Smiles = "CCO".parse().unwrap();
+    let f = m.fragment_from_atoms([0, 1]).unwrap();
+    assert_eq!(f.atom_count(), 2);
+    // The central carbon, now terminal, gains hydrogens: both become methyl.
+    assert_eq!(f.smiles().render(), "CC");
+}
+
+#[test]
+fn from_bonds_uses_endpoints_only() {
+    let m: Smiles = "CCO".parse().unwrap();
+    let f = m.fragment_from_bonds([bond_edge(0, 1, Bond::Single, None)]).unwrap();
+    assert_eq!(f.smiles().render(), "CC");
+}
+
+#[test]
+fn maps_round_trip() {
+    let m: Smiles = "CCO".parse().unwrap();
+    let f = m.fragment_from_atoms([2, 1]).unwrap();
+    assert_eq!(f.local_id(2), Some(0));
+    assert_eq!(f.local_id(1), Some(1));
+    assert_eq!(f.local_id(0), None);
+    assert_eq!(f.parent_id(0), 2);
+    assert_eq!(f.parent_id(1), 1);
+}
+
+#[test]
+fn render_rooted_anchors_at_parent_atom() {
+    let m: Smiles = "CCO".parse().unwrap();
+    let f = m.fragment_from_atoms([0, 1, 2]).unwrap();
+    assert!(f.render_rooted(2, true).unwrap().starts_with('O'));
+}
+
+#[test]
+fn render_rooted_non_isomeric_drops_stereo() {
+    let m: Smiles = "N[C@@H](C)C(=O)O".parse().unwrap();
+    let f = m.fragment_from_atoms(0..m.nodes().len()).unwrap();
+    assert!(!f.render_rooted(1, false).unwrap().contains('@'));
+}
+
+#[test]
+fn benzene_fragment_round_trips() {
+    let m: Smiles = "c1ccccc1".parse().unwrap();
+    let f = m.fragment_from_atoms(0..6).unwrap();
+    assert_eq!(f.smiles().canonicalize().render(), m.canonicalize().render());
+}
+
+#[test]
+fn equivalent_environments_share_label() {
+    let m: Smiles = "c1ccccc1".parse().unwrap();
+    let a = m.fragment_from_atoms([0, 1, 2]).unwrap().render_rooted(1, false).unwrap();
+    let b = m.fragment_from_atoms([1, 2, 3]).unwrap().render_rooted(2, false).unwrap();
+    assert_eq!(a, b, "symmetric benzene environments must share a label");
+}
+
+#[test]
+fn rooted_label_is_numbering_invariant() {
+    // Isomorphic environments must collapse to one label regardless of the
+    // fragment's internal atom numbering (core MAP4 requirement).
+    let m: Smiles = "Cc1ccccc1".parse().unwrap();
+    for center in 0..m.nodes().len() {
+        let Some(env) = m.atom_environment(center, 2) else { continue };
+        let atoms: Vec<usize> = env.atoms().collect();
+        let reversed: Vec<usize> = atoms.iter().rev().copied().collect();
+        let forward = m.fragment_from_atoms(atoms).unwrap().render_rooted(center, false).unwrap();
+        let backward =
+            m.fragment_from_atoms(reversed).unwrap().render_rooted(center, false).unwrap();
+        assert_eq!(forward, backward, "center {center}");
+    }
+}
+
+#[test]
+fn out_of_range_atom_errors() {
+    let m: Smiles = "CCO".parse().unwrap();
+    assert!(m.fragment_from_atoms([0, 99]).is_err());
+}
+
+#[test]
+fn render_rooted_errors_for_absent_atom() {
+    let m: Smiles = "CCO".parse().unwrap();
+    let f = m.fragment_from_atoms([0, 1]).unwrap();
+    assert!(f.render_rooted(2, true).is_err());
+}
+
+#[test]
+fn into_smiles_returns_owned() {
+    let m: Smiles = "CCO".parse().unwrap();
+    let owned = m.fragment_from_atoms([0, 1]).unwrap().into_smiles();
+    assert_eq!(owned.render(), "CC");
+}
+
+#[test]
+fn from_bonds_out_of_range_endpoint_errors() {
+    let m: Smiles = "CCO".parse().unwrap();
+    // Target endpoint out of range.
+    let err = m.fragment_from_bonds([bond_edge(0, 99, Bond::Single, None)]);
+    assert_eq!(err.unwrap_err(), SubgraphError::AtomOutOfRange(99));
+    // Source endpoint out of range.
+    let err = m.fragment_from_bonds([bond_edge(99, 0, Bond::Single, None)]);
+    assert_eq!(err.unwrap_err(), SubgraphError::AtomOutOfRange(99));
+}
+
+#[test]
+fn from_bonds_non_edge_errors() {
+    // Atoms 0 and 2 of CCO are valid but not bonded to each other.
+    let m: Smiles = "CCO".parse().unwrap();
+    let err = m.fragment_from_bonds([bond_edge(0, 2, Bond::Single, None)]);
+    assert_eq!(err.unwrap_err(), SubgraphError::BondReferencesUnknownAtom(2));
+}

--- a/tests/test_non_isomeric.rs
+++ b/tests/test_non_isomeric.rs
@@ -1,0 +1,36 @@
+//! Non-isomeric normalization tests.
+use smiles_parser::prelude::Smiles;
+
+fn ni(s: &str) -> String {
+    s.parse::<Smiles>().unwrap().non_isomeric().render()
+}
+
+#[test]
+fn drops_isotopes() {
+    assert!(!ni("[13CH3]O").contains("13"));
+    assert_eq!(ni("[13CH3]O"), ni("[12CH3]O"));
+}
+
+#[test]
+fn drops_tetrahedral_chirality() {
+    let r = ni("N[C@@H](C)C(=O)O");
+    assert!(!r.contains('@'), "got {r}");
+    assert_eq!(ni("N[C@@H](C)C(=O)O"), ni("N[C@H](C)C(=O)O"));
+}
+
+#[test]
+fn drops_double_bond_stereo() {
+    let r = ni("F/C=C/F");
+    assert!(!r.contains('/') && !r.contains('\\'), "got {r}");
+    assert_eq!(ni("F/C=C/F"), ni("F/C=C\\F"));
+}
+
+#[test]
+fn preserves_skeleton_and_is_idempotent() {
+    for s in ["[13CH3]O", "N[C@@H](C)C(=O)O", "F/C=C/F", "c1ccccc1", "CCO"] {
+        let once = s.parse::<Smiles>().unwrap().non_isomeric();
+        assert_eq!(once.render(), once.non_isomeric().render(), "{s} not idempotent");
+        // same heavy-atom count
+        assert_eq!(once.nodes().len(), s.parse::<Smiles>().unwrap().nodes().len(), "{s}");
+    }
+}

--- a/tests/test_rooted_environment_smiles.rs
+++ b/tests/test_rooted_environment_smiles.rs
@@ -1,0 +1,37 @@
+//! One-shot MAP4 substructure label + public export checks.
+use smiles_parser::prelude::{AtomEnvironment, Fragment, RootError, Smiles, SubgraphError};
+
+fn canon(s: &str) -> String {
+    s.parse::<Smiles>().unwrap().canonicalize().render()
+}
+
+#[test]
+fn empty_shell_folds_to_none() {
+    let m: Smiles = "CCO".parse().unwrap();
+    assert!(m.rooted_environment_smiles(1, 2, false).is_none());
+    assert!(m.rooted_environment_smiles(0, 0, false).is_none());
+}
+
+#[test]
+fn produces_centered_label() {
+    let m: Smiles = "CCO".parse().unwrap();
+    let label = m.rooted_environment_smiles(0, 2, false).unwrap();
+    assert_eq!(canon(&label), canon("CCO"));
+}
+
+#[test]
+fn isotopes_collapse_under_non_isomeric() {
+    let a: Smiles = "[13CH3]CO".parse().unwrap();
+    let b: Smiles = "[12CH3]CO".parse().unwrap();
+    assert_eq!(a.rooted_environment_smiles(0, 2, false), b.rooted_environment_smiles(0, 2, false),);
+}
+
+// Type-level check that the public surface is exported through the prelude.
+#[allow(dead_code)]
+fn exports_are_public(
+    _env: AtomEnvironment<'_>,
+    _frag: Fragment,
+    _e: SubgraphError,
+    _r: RootError,
+) {
+}

--- a/tests/test_rooted_render.rs
+++ b/tests/test_rooted_render.rs
@@ -1,0 +1,101 @@
+//! Root-anchored rendering tests.
+use smiles_parser::prelude::Smiles;
+
+fn canon(s: &str) -> String {
+    s.parse::<Smiles>().unwrap().canonicalize().render()
+}
+
+fn first_atom(s: &str) -> String {
+    format!("{:?}", s.parse::<Smiles>().unwrap().node_by_id(0).unwrap())
+}
+
+#[test]
+fn deterministic() {
+    let m: Smiles = "Cc1ccccc1".parse().unwrap();
+    for r in 0..m.nodes().len() {
+        assert_eq!(m.render_rooted(r), m.render_rooted(r));
+    }
+}
+
+#[test]
+fn round_trips_same_molecule() {
+    for s in ["CCO", "Cc1ccccc1", "CC(=O)O", "c1ccccc1", "FC(Cl)Br", "C1CC1.CC"] {
+        let m: Smiles = s.parse().unwrap();
+        for r in 0..m.nodes().len() {
+            assert_eq!(canon(&m.render_rooted(r)), canon(s), "{s}@{r}");
+        }
+    }
+}
+
+#[test]
+fn rooting_is_independent_of_root_for_tricky_stereo() {
+    // Pathological input (aromatic atoms outside a ring, adjacent cumulated
+    // double bond with directional stereo) from a fuzz finding: every root must
+    // render to the same molecule as the default render().
+    let m: Smiles = "CCOCNO=FNO=cc/CNC".parse().unwrap();
+    let base = m.render().parse::<Smiles>().unwrap().canonicalize().render();
+    for r in 0..m.nodes().len() {
+        let rooted = m.render_rooted(r).parse::<Smiles>().unwrap().canonicalize().render();
+        assert_eq!(rooted, base, "root {r}");
+    }
+}
+
+#[test]
+fn starts_at_root() {
+    for s in ["CCO", "Cc1ccccc1", "FC(Cl)Br", "c1ccccc1"] {
+        let m: Smiles = s.parse().unwrap();
+        for r in 0..m.nodes().len() {
+            assert_eq!(
+                first_atom(&m.render_rooted(r)),
+                format!("{:?}", m.node_by_id(r).unwrap()),
+                "{s}@{r}"
+            );
+        }
+    }
+}
+
+#[test]
+fn matches_default_and_differs_by_root() {
+    let m: Smiles = "CCO".parse().unwrap();
+    assert_eq!(m.render_rooted(0), m.render());
+    assert_ne!(m.render_rooted(0), m.render_rooted(2));
+    assert!(m.render_rooted(2).starts_with('O'));
+}
+
+#[test]
+#[should_panic(expected = "root")]
+fn panics_oob() {
+    let _ = "CCO".parse::<Smiles>().unwrap().render_rooted(3);
+}
+
+#[test]
+fn labeling_rooted() {
+    for s in ["CCO", "Cc1ccccc1", "FC(Cl)Br"] {
+        let m: Smiles = s.parse().unwrap();
+        for r in 0..m.nodes().len() {
+            let l = m.canonical_labeling_rooted(r);
+            assert_eq!(l.order()[0], r);
+            assert_eq!(l.new_index_of_old_node()[r], 0);
+            let mut seen = l.order().to_vec();
+            seen.sort_unstable();
+            assert_eq!(seen, (0..m.nodes().len()).collect::<Vec<_>>());
+        }
+    }
+}
+
+#[test]
+fn labeling_rooted_multi_component_is_valid_permutation() {
+    // With several components, root leads its own run but need not be ordinal 0.
+    let m: Smiles = "C1CC1.CC".parse().unwrap();
+    let l = m.canonical_labeling_rooted(4);
+    let mut seen = l.order().to_vec();
+    seen.sort_unstable();
+    assert_eq!(seen, (0..m.nodes().len()).collect::<Vec<_>>());
+    assert!(l.order().contains(&4));
+}
+
+#[test]
+#[should_panic(expected = "root")]
+fn labeling_panics_oob() {
+    let _ = "CCO".parse::<Smiles>().unwrap().canonical_labeling_rooted(3);
+}


### PR DESCRIPTION
Adds the public methods finge-rs needs to build MAP4 fingerprints: atom_environment for radius-N circular environments (RDKit FindAtomEnvironmentOfRadiusN semantics, including the empty-shell rule), Fragment construction from atom or bond sets with fragment-local hydrogen recomputation, render_rooted for traversal anchored at a chosen atom, and non_isomeric to drop stereo and isotopes. A one-shot rooted_environment_smiles composes these into the per-atom MAP4 label. Covered by unit tests and a new rooted_render fuzz target, with the new code fully line-covered.