### PR TITLE
Support aromatic silicon ([si], [siH])

### DIFF
--- a/src/atom/mod.rs
+++ b/src/atom/mod.rs
@@ -833,6 +833,7 @@ pub(crate) fn can_write_unbracketed_aromatic(element: Element) -> bool {
 fn bracket_aromatic_smiles_symbol(element: Element) -> Option<&'static str> {
     match element {
         Element::Te => Some("te"),
+        Element::Si => Some("si"),
         _ => element.aromatic_smiles_symbol(),
     }
 }
@@ -1065,6 +1066,11 @@ mod tests {
         assert_eq!(rendered_symbol_len(ac_symbol(), true, AtomSyntax::OrganicSubset), 2);
         assert_eq!(
             rendered_symbol_len(AtomSymbol::Element(Element::Te), true, AtomSyntax::Bracket,),
+            2
+        );
+        assert_eq!(bracket_aromatic_smiles_symbol(Element::Si), Some("si"));
+        assert_eq!(
+            rendered_symbol_len(AtomSymbol::Element(Element::Si), true, AtomSyntax::Bracket,),
             2
         );
 

--- a/src/parser/token_iter.rs
+++ b/src/parser/token_iter.rs
@@ -211,6 +211,7 @@ fn aromatic_from_element(in_bracket: bool, element: Element) -> Result<bool, Smi
                 | Element::Se
                 | Element::As
                 | Element::Te
+                | Element::Si
         )
     } else {
         matches!(
@@ -761,7 +762,12 @@ mod tests {
         assert_eq!(aromatic_from_element(false, Element::C), Ok(true));
         assert_eq!(aromatic_from_element(true, Element::Se), Ok(true));
         assert_eq!(aromatic_from_element(true, Element::Te), Ok(true));
+        assert_eq!(aromatic_from_element(true, Element::Si), Ok(true));
 
+        assert_eq!(
+            aromatic_from_element(false, Element::Si),
+            Err(SmilesError::InvalidAromaticElement(Element::Si))
+        );
         assert_eq!(
             aromatic_from_element(false, Element::Se),
             Err(SmilesError::InvalidAromaticElement(Element::Se))


### PR DESCRIPTION
Aromatic silicon written as `[si]` or `[siH]` is a commonly seen irregular SMILES form that previously failed to parse with an `InvalidAromaticElement` error.

This allows Si as an aromatic element inside brackets and maps it to the `si` spelling when rendering bracket atoms so it round-trips. Lowercase aromatic Si is only valid in brackets (never part of the organic subset), so only the in-bracket list needed it.

Downstream handling already covered Si: kekulization lists it in its candidate-valence table, and bracket atoms never gain implicit hydrogens.