### PR TITLE
Collapse redundant brackets in non_isomeric()

### DIFF
--- a/src/smiles/canonicalization.rs
+++ b/src/smiles/canonicalization.rs
@@ -216,7 +216,7 @@ impl<AtomPolicy: crate::smiles::SmilesAtomPolicy> Smiles<AtomPolicy> {
         self.stereo_normal_form().exact_canonicalize().canonicalization_spelling_normal_form()
     }
 
-    fn canonicalization_spelling_normal_form(&self) -> Self {
+    pub(super) fn canonicalization_spelling_normal_form(&self) -> Self {
         let atom_nodes = self
             .atom_nodes
             .iter()

--- a/src/smiles/mod.rs
+++ b/src/smiles/mod.rs
@@ -1239,12 +1239,18 @@ impl<AtomPolicy: SmilesAtomPolicy> Smiles<AtomPolicy> {
                 .unwrap_or_else(|_| unreachable!("non-isomeric copy preserves a simple graph"));
         }
         let parsed_stereo_neighbors = vec![Vec::new(); atom_nodes.len()];
-        Self::from_bond_matrix_parts_with_parsed_stereo_and_source(
+        let result = Self::from_bond_matrix_parts_with_parsed_stereo_and_source(
             atom_nodes,
             builder.finish(self.atom_nodes.len()),
             parsed_stereo_neighbors,
             None,
-        )
+        );
+        // Clearing isotope and stereo can leave an atom bracketed for a reason
+        // that no longer applies (e.g. `[13CH3]` -> `[CH3]`). Collapse such
+        // atoms to the bare organic-subset form using the same eligibility rule
+        // as canonicalization, so `non_isomeric()` is order-independent with
+        // respect to `canonicalize()`.
+        result.canonicalization_spelling_normal_form()
     }
 
     fn ring_membership_with_packed_bridge_keys(&self, bond_count: usize) -> RingMembership {

--- a/tests/test_non_isomeric.rs
+++ b/tests/test_non_isomeric.rs
@@ -34,3 +34,46 @@ fn preserves_skeleton_and_is_idempotent() {
         assert_eq!(once.nodes().len(), s.parse::<Smiles>().unwrap().nodes().len(), "{s}");
     }
 }
+
+#[test]
+fn order_independent_with_canonicalize() {
+    // non_isomeric() must be order-independent with respect to canonicalization:
+    // clearing the isotope must also drop the bracket it forced.
+    for s in ["C[13CH3]", "[12CH4]", "C[OH]"] {
+        let m: Smiles = s.parse().unwrap();
+        assert_eq!(
+            m.canonicalize().non_isomeric().render(),
+            m.non_isomeric().canonicalize().render(),
+            "{s} order-dependent",
+        );
+    }
+}
+
+#[test]
+fn collapses_brackets_left_by_cleared_isotope() {
+    assert_eq!(ni("C[13CH3]"), "CC");
+    assert_eq!(ni("[12CH4]"), "C");
+}
+
+#[test]
+fn keeps_brackets_that_are_still_required() {
+    // charge, aromatic N-H, and an explicit hydrogen atom each force a bracket
+    // that survives non-isomeric normalization.
+    for s in ["C[NH3+]", "c1cc[nH]c1", "[H]C"] {
+        let m: Smiles = s.parse().unwrap();
+        assert!(m.non_isomeric().render().contains('['), "{s} lost a required bracket");
+    }
+}
+
+#[test]
+fn fragment_label_collapses_bracket_forced_aromatic_nitrogen() {
+    // MAP4 fragment labels go through non_isomeric().render_rooted, so the
+    // bracket-forced aromatic nitrogen must collapse in the fragment label.
+    let m: Smiles = "[CH3][Ga]([CH3])[n]1cccn1".parse().unwrap();
+    for (atom_id, atom) in m.nodes().iter().enumerate() {
+        if atom.aromatic() {
+            let label = m.rooted_environment_smiles(atom_id, 1, false).unwrap();
+            assert!(!label.contains("[n]"), "atom {atom_id} label {label} kept [n]");
+        }
+    }
+}


### PR DESCRIPTION
non_isomeric() cleared isotope and stereo but never re-checked whether an atom still needed brackets, so a bracket forced only by an isotope (or inherited by a fragment) survived. That made non_isomeric() order-dependent with respect to canonicalize():

```
C[13CH3].canonicalize().non_isomeric().render()  ==  C[CH3]   (wrong)
C[13CH3].non_isomeric().canonicalize().render()  ==  CC       (right)
```

The same gap left MAP4 fragment labels emitting [n] where n was correct, since fragment labels route through non_isomeric().render_rooted.

Fix: after building the non-isomeric graph, run the existing canonicalization_spelling_normal_form collapse pass, which reuses maybe_collapse_atom_to_organic_subset rather than duplicating the rule. Atoms that still need a bracket (nonzero charge, aromatic N-H, explicit H atom, metals, atom maps) are kept. This fixes both the isotope case and the fragment [n] case in one place and restores non_isomeric() idempotence with respect to canonical form.

Tests: order-independence vs canonicalize for C[13CH3]/[12CH4]/C[OH], collapse of C[13CH3] to CC and [12CH4] to C, bracket-retention controls (C[NH3+], c1cc[nH]c1, [H]C), and a MAP4 fragment-label check on [CH3][Ga]([CH3])[n]1cccn1.