### PR TITLE
Ignore kekule order of aromatic bonds in canonical ordering

### DIFF
--- a/src/smiles/canonicalization/state.rs
+++ b/src/smiles/canonicalization/state.rs
@@ -85,6 +85,16 @@ pub(super) fn canonicalization_state_key<AtomPolicy: SmilesAtomPolicy>(
 }
 
 pub(super) const fn canonical_bond_label(entry: BondEntry) -> CanonicalBondLabel {
+    // The aromatic flag fully determines an aromatic bond: the single/double
+    // kekule order retained alongside the flag is non-semantic. Collapse every
+    // aromatic bond to one canonical code so that two graphs which differ only
+    // in the kekule assignment of their aromatic bonds (e.g. a raw aromatic
+    // parse versus its kekulize-then-reperceive round-trip) canonicalize
+    // identically, including on broken-ring fragments where the order would
+    // otherwise leak into the rendered label.
+    if entry.aromatic() {
+        return CanonicalBondLabel(8);
+    }
     let bond_code = match entry.bond() {
         crate::bond::Bond::Single => 0,
         crate::bond::Bond::Double => 1,
@@ -93,7 +103,7 @@ pub(super) const fn canonical_bond_label(entry: BondEntry) -> CanonicalBondLabel
         crate::bond::Bond::Up => 4,
         crate::bond::Bond::Down => 5,
     };
-    CanonicalBondLabel(bond_code + if entry.aromatic() { 8 } else { 0 })
+    CanonicalBondLabel(bond_code)
 }
 
 pub(crate) const fn canonical_chirality_key(chirality: Option<Chirality>) -> (u8, u8) {

--- a/src/smiles/invariants.rs
+++ b/src/smiles/invariants.rs
@@ -17,9 +17,15 @@ pub(crate) struct BondKindHistogram {
 impl BondKindHistogram {
     #[inline]
     pub(crate) fn record(&mut self, entry: BondEntry) {
-        self.counts[bond_kind_index(entry.bond())] += 1;
+        // The single/double kekule order retained on an aromatic bond is
+        // non-semantic, so an aromatic bond is counted only as aromatic and
+        // never under its kekule kind. This keeps the histogram (and every
+        // ordering derived from it) identical for two representations that
+        // differ only in the kekule assignment of their aromatic bonds.
         if entry.aromatic() {
             self.aromatic_count += 1;
+        } else {
+            self.counts[bond_kind_index(entry.bond())] += 1;
         }
     }
 
@@ -100,7 +106,12 @@ pub(crate) const fn bond_kind_code(bond: Bond) -> u8 {
 
 #[inline]
 pub(crate) const fn bond_descriptor_code(descriptor: BondDescriptor) -> u8 {
-    bond_kind_code(descriptor.bond()) + if descriptor.is_aromatic() { 8 } else { 0 }
+    // An aromatic bond collapses to a single canonical code: its kekule order
+    // must not influence ordering or signatures (see `BondKindHistogram`).
+    if descriptor.is_aromatic() {
+        return 8;
+    }
+    bond_kind_code(descriptor.bond())
 }
 
 #[inline]
@@ -110,7 +121,12 @@ pub(crate) const fn bond_descriptor_index(descriptor: BondDescriptor) -> usize {
 
 #[inline]
 pub(crate) const fn bond_entry_code(entry: BondEntry) -> u8 {
-    bond_kind_code(entry.bond()) + if entry.aromatic() { 8 } else { 0 }
+    // An aromatic bond collapses to a single canonical code: its kekule order
+    // must not influence ordering or signatures (see `BondKindHistogram`).
+    if entry.aromatic() {
+        return 8;
+    }
+    bond_kind_code(entry.bond())
 }
 
 #[inline]
@@ -236,7 +252,9 @@ mod tests {
 
         let invariant = smiles.atom_invariant(0).unwrap();
         assert_eq!(invariant.degree, 3);
-        assert_eq!(invariant.bond_kind_histogram.count(Bond::Single), 2);
+        // The aromatic bond is counted only as aromatic, never under its kekule
+        // kind, so the plain single bond is the only one in the Single bucket.
+        assert_eq!(invariant.bond_kind_histogram.count(Bond::Single), 1);
         assert_eq!(invariant.bond_kind_histogram.count(Bond::Double), 1);
         assert_eq!(invariant.bond_kind_histogram.aromatic_count(), 1);
     }

--- a/tests/test_aromatic_bond_order_canonicalization.rs
+++ b/tests/test_aromatic_bond_order_canonicalization.rs
@@ -1,0 +1,63 @@
+//! Aromatic-bond-order representation invariance for canonicalization and
+//! rooted environment SMILES.
+//!
+//! The single/double kekule order retained on an aromatic bond is non-semantic:
+//! two representations of the same molecule that differ only in that order must
+//! canonicalize identically and produce identical rooted-environment labels,
+//! including on broken-ring fragments carved by the MAP4 path.
+use smiles_parser::smiles::{AromaticityPolicy, Smiles};
+
+/// Kekulize, then re-perceive RDKit-default aromaticity: an equivalent
+/// representation of the molecule that retains kekule orders on aromatic bonds.
+fn roundtrip(m: &Smiles) -> Smiles {
+    m.kekulize_standalone()
+        .unwrap()
+        .perceive_aromaticity_for(AromaticityPolicy::RdkitDefault)
+        .unwrap()
+        .into_aromaticized()
+}
+
+#[test]
+fn rooted_environment_is_representation_independent() {
+    for smiles in ["Cc1ccc(C)cc1", "Cc1ccccc1", "c1ccc2ccccc2c1", "O=C(O)c1ccccc1"] {
+        let raw: Smiles = smiles.parse().unwrap();
+        let norm = roundtrip(&raw);
+        assert_eq!(raw.nodes().len(), norm.nodes().len());
+        for i in 0..raw.nodes().len() {
+            for r in 1..=3 {
+                assert_eq!(
+                    raw.rooted_environment_smiles(i, r, false),
+                    norm.rooted_environment_smiles(i, r, false),
+                    "{smiles} atom {i} radius {r} is representation-dependent",
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn broken_ring_fragment_canonicalizes_independently_of_kekule_order() {
+    let raw: Smiles = "Cc1ccc(C)cc1".parse().unwrap();
+    let norm = roundtrip(&raw);
+    let raw_frag = raw.atom_environment(6, 2).unwrap().to_fragment().unwrap();
+    let norm_frag = norm.atom_environment(6, 2).unwrap().to_fragment().unwrap();
+    assert_eq!(
+        raw_frag.smiles().canonicalize().render(),
+        norm_frag.smiles().canonicalize().render(),
+    );
+}
+
+#[test]
+fn whole_molecule_canonical_form_unchanged() {
+    let raw: Smiles = "Cc1ccc(C)cc1".parse().unwrap();
+    let norm = roundtrip(&raw);
+    assert_eq!(raw.canonicalize().render(), norm.canonicalize().render());
+}
+
+#[test]
+fn rooted_environment_matches_rdkit_style_value() {
+    let raw: Smiles = "Cc1ccc(C)cc1".parse().unwrap();
+    let norm = roundtrip(&raw);
+    assert_eq!(raw.rooted_environment_smiles(6, 2, false).unwrap(), "c(cc)c(C)c");
+    assert_eq!(norm.rooted_environment_smiles(6, 2, false).unwrap(), "c(cc)c(C)c");
+}


### PR DESCRIPTION
The single/double kekule order retained on a bond that is flagged aromatic is non-semantic: the aromatic flag already determines the bond. Canonical labeling and render-plan ordering treated that order as significant, so two representations of the same molecule that differ only in kekule assignment on their aromatic bonds (a raw aromatic parse versus its kekulize-then-reperceive round-trip) could order atoms differently. On a closed ring this is masked by canonical re-kekulization, but a broken-ring fragment carved for a MAP4 environment cannot be re-kekulized, so the order leaked into the rendered label and made rooted_environment_smiles representation-dependent.

Example (p-xylene, radius-2 environment of atom 6):

```
raw.rooted_environment_smiles(6, 2, false)  == c(cc)c(C)c   (before and after)
norm.rooted_environment_smiles(6, 2, false) == c(c(C)c)cc   (before)  ->  c(cc)c(C)c (after)
```

Fix: collapse every aromatic bond to one canonical code wherever bond order feeds ordering or signatures.

- canonical_bond_label (canonicalization labeling and state key)
- bond_entry_code and bond_descriptor_code (refinement, branch, and neighbor ordering, symmetry)
- BondKindHistogram::record (an aromatic bond is now counted only as aromatic, never under its kekule kind)

Each of these now emits a strict subset of its previous code range, so no downstream index sizing changes. The whole-molecule canonical form is unchanged.

Verification: full test suite, doctests, fmt, and clippy clean. Representation invariance swept over 212,659 aromatic molecules from the CID-SMILES corpus with zero canonicalize() mismatches and zero rooted-environment mismatches between the raw aromatic form and its kekulize-reperceive round-trip. New tests in tests/test_aromatic_bond_order_canonicalization.rs pin the invariance and the exact RDKit-style value.