### PR TITLE
Add cargo-mutants CI and close mutation-testing gaps

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -1,0 +1,8 @@
+# cargo-mutants configuration.
+#
+# datasets.rs is network and IO glue whose tests are #[ignore]d and gated on
+# downloading PubChem and ZINC20 corpora, so it cannot be mutation tested in a
+# normal `cargo test` run. Excluding it keeps the gate fair: a pull request that
+# edits datasets.rs is not asked to kill mutants no offline test could ever
+# catch.
+exclude_globs = ["src/datasets.rs"]

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -1,0 +1,31 @@
+name: Mutation Testing
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  mutants:
+    name: cargo-mutants (PR diff)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+      - name: Cache build artifacts
+        uses: Swatinem/rust-cache@v2
+      - name: Install cargo-mutants
+        uses: taiki-e/install-action@cargo-mutants
+      - name: Compute diff against base branch
+        run: git diff origin/${{ github.base_ref }} > pr.diff
+      - name: Run cargo-mutants on changed lines
+        run: cargo mutants --no-shuffle -vV --in-diff pr.diff
+      - name: Upload mutation results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mutants.out
+          path: mutants.out

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ fuzzer_pub_chem_corpus/
 tests/fixtures/*.tsv.gz
 *.log
 fuzz/corpus
+mutants.out/
+mutants.out.old/
+pr.diff

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,17 @@ pedantic = { level = "deny", priority = -1 }
 [profile.release]
 lto = "thin"
 codegen-units = 1
+
+# Optimize dependencies in dev and test builds so the graph algorithms (notably
+# the NP-hard MCES from geometric-traits) do not run unoptimized. This cuts the
+# unit-test suite from about 18s to about 6s while leaving this crate at the
+# default opt-level 0, so per-mutant rebuilds under cargo-mutants stay fast.
+# Optimizing this crate too would drop tests to under 1s but make every
+# incremental rebuild far slower, which is a net loss for the build-bound
+# mutation workflow. The dependency build is a one-time, cacheable cost.
+[profile.dev.package."*"]
+opt-level = 3
+
 [dev-dependencies]
 criterion = { version = "0.8.2", default-features = false, features = ["cargo_bench_support"] }
 flate2 = "1.1.9"

--- a/src/atom/mod.rs
+++ b/src/atom/mod.rs
@@ -1028,6 +1028,11 @@ mod tests {
         assert!(atom_type.aromatic());
         assert_eq!(atom_type.isotope_mass_number(), Some(80));
         assert_eq!(atom_type.formal_charge(), -1);
+
+        // The accessor must report the stored flag rather than a constant, so an
+        // aliphatic atom reads back as non-aromatic.
+        let aliphatic = Atom::new_organic_subset(AtomSymbol::Element(Element::C), false);
+        assert!(!aliphatic.node_type().aromatic());
     }
 
     #[test]
@@ -1112,6 +1117,46 @@ mod tests {
         atom.write_smiles(&mut rendered).unwrap();
 
         assert_eq!(rendered, "[*]");
+    }
+
+    #[test]
+    fn can_write_unbracketed_aromatic_accepts_only_the_organic_aromatic_subset() {
+        for element in [Element::B, Element::C, Element::N, Element::O, Element::P, Element::S] {
+            assert!(can_write_unbracketed_aromatic(element), "{element} should be unbracketed");
+        }
+        for element in [Element::Si, Element::Se, Element::Te, Element::As, Element::F, Element::Cl]
+        {
+            assert!(!can_write_unbracketed_aromatic(element), "{element} should need brackets");
+        }
+    }
+
+    #[test]
+    fn rendered_len_hint_matches_actual_length_across_bracket_fields() {
+        // The capacity hint must equal the rendered length so the render buffer
+        // is sized exactly. A one-character symbol breaks the coincidence where
+        // adding the two bracket characters equals doubling a two-character
+        // symbol, and the isotope and chirality cases exercise the per-field
+        // additions that no other hint assertion reaches.
+        let cases = [
+            Atom::builder().with_symbol(AtomSymbol::Element(Element::C)).build(),
+            Atom::builder().with_symbol(AtomSymbol::Element(Element::C)).with_isotope(13).build(),
+            Atom::builder()
+                .with_symbol(AtomSymbol::Element(Element::C))
+                .with_chirality(Chirality::At)
+                .build(),
+            Atom::builder()
+                .with_symbol(AtomSymbol::Element(Element::C))
+                .with_isotope(13)
+                .with_chirality(Chirality::TH(2))
+                .with_hydrogens(2)
+                .with_charge(Charge::try_new(-1).unwrap())
+                .with_class(7)
+                .build(),
+        ];
+        for atom in cases {
+            let rendered = atom.rendered_string();
+            assert_eq!(atom.rendered_len_hint(), rendered.len(), "hint mismatch for {rendered}");
+        }
     }
 
     #[test]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -414,6 +414,19 @@ mod tests {
     }
 
     #[test]
+    fn render_marks_zero_width_and_multi_character_spans() {
+        // A zero-width span (start == end) must still produce exactly one caret,
+        // which only holds because the end is raised to at least start + 1.
+        let zero_width = SmilesErrorWithSpan::new(SmilesError::UnexpectedEndOfString, 2, 2);
+        assert_eq!(zero_width.render("CCO"), "CCO\n  ^\nUnexpected end of string");
+
+        // A multi-character span draws one caret per covered position, so the
+        // caret run width is end minus start rather than any other combination.
+        let two_wide = SmilesErrorWithSpan::new(SmilesError::UnexpectedCharacter('x'), 1, 3);
+        assert_eq!(two_wide.render("CCCC"), "CCCC\n ^^\nUnexpected character: x");
+    }
+
+    #[test]
     fn test_smiles_error_with_unicode_span() {
         let error = SmilesErrorWithSpan::new(SmilesError::UnexpectedUnicodeCharacter, 2, 4);
 

--- a/src/smiles/invariants.rs
+++ b/src/smiles/invariants.rs
@@ -149,8 +149,8 @@ mod tests {
     use elements_rs::Element;
 
     use super::{
-        AtomInvariant, BondKindHistogram, Smiles, bond_kind_code, bond_kind_index,
-        planning_chirality_key,
+        AtomInvariant, BondEntry, BondKindHistogram, Smiles, bond_entry_code, bond_kind_code,
+        bond_kind_index, planning_chirality_key,
     };
     use crate::{
         atom::{
@@ -159,7 +159,7 @@ mod tests {
             bracketed::{charge::Charge, chirality::Chirality},
         },
         bond::{
-            Bond,
+            Bond, BondDescriptor,
             bond_edge::{BondEdge, bond_edge},
         },
         smiles::BondMatrixBuilder,
@@ -311,6 +311,25 @@ mod tests {
         assert_eq!(bond_kind_index(Bond::Up), bond_kind_index(Bond::Down));
         assert_ne!(bond_kind_index(Bond::Single), bond_kind_index(Bond::Double));
         assert_ne!(bond_kind_index(Bond::Triple), bond_kind_index(Bond::Quadruple));
+    }
+
+    #[test]
+    fn bond_entry_code_collapses_aromatic_and_separates_kekule_kinds() {
+        // An aromatic bond collapses to code 8 regardless of its kekule order,
+        // so an aromatic single and an aromatic double share one code and never
+        // collide with a plain single (0) or double (1).
+        let aromatic_single =
+            BondEntry::from_descriptor(BondDescriptor::aromatic(Bond::Single), None, 0);
+        let aromatic_double =
+            BondEntry::from_descriptor(BondDescriptor::aromatic(Bond::Double), None, 0);
+        assert_eq!(bond_entry_code(aromatic_single), 8);
+        assert_eq!(bond_entry_code(aromatic_double), 8);
+
+        // Non-aromatic bonds keep their distinct kekule codes.
+        assert_eq!(bond_entry_code(BondEntry::new(Bond::Single, None, 0)), 0);
+        assert_eq!(bond_entry_code(BondEntry::new(Bond::Double, None, 0)), 1);
+        assert_eq!(bond_entry_code(BondEntry::new(Bond::Triple, None, 0)), 2);
+        assert_eq!(bond_entry_code(BondEntry::new(Bond::Quadruple, None, 0)), 3);
     }
 
     #[test]


### PR DESCRIPTION
This adds a `cargo-mutants` job that runs on each pull request against the changed lines only (`--in-diff`), so it gates just what a PR touches. It uses `Swatinem/rust-cache` and a 30 minute timeout, and `.cargo/mutants.toml` excludes `datasets.rs` because that file is network and IO glue whose tests are `#[ignore]`d and cannot be mutation tested offline.

Mutation runs rebuild and re-test once per mutant, so a `[profile.dev.package."*"] opt-level = 3` override optimizes dependencies (notably the NP-hard MCES from `geometric-traits`, which monomorphizes into this crate) and cuts the unit-test suite from about 18s to about 6s. This crate itself stays at `opt-level` 0 so per-mutant rebuilds stay fast, and the dependency build is a one-time cacheable cost.

It also closes the mutation gaps the new gate surfaced. Tests now pin `bond_entry_code`, the `McesAtomType::aromatic` and `can_write_unbracketed_aromatic` accessors, the `rendered_len_hint_with_chirality` arithmetic, and the caret rendering in `SmilesErrorWithSpan::render`. The two surviving `<` versus `<=` mutants in `edge_key` and `contains_edge` are equivalent mutants, since both operators behave identically when the two node ids differ and produce the same pair when they are equal, so they are left untouched.
